### PR TITLE
feat: ACE statusline — script, setup command, and docs

### DIFF
--- a/plugins/ace/commands/ace-statusline-setup.md
+++ b/plugins/ace/commands/ace-statusline-setup.md
@@ -68,6 +68,11 @@ Searched:
   2. ~/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh
   3. ~/Library/Application Support/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh
 
+If the ACE plugin is installed under a different marketplace directory name, the
+paths above will not match. Check the actual install location with:
+  ls ~/.config/claude-code/marketplaces/
+  ls ~/Library/Application\ Support/claude-code/marketplaces/
+
 To wire a custom location manually:
   1. Create .claude/statusline-command.sh containing:
        #!/usr/bin/env bash
@@ -89,15 +94,16 @@ grep -qF "<STATUSLINE_PATH>" .claude/statusline-command.sh 2>/dev/null && echo "
 ```
 
 **Decision**:
-- Output is `ALREADY_WIRED`: The statusline is already pointing to this exact script. Tell the user:
+- Output is `ALREADY_WIRED`: The wrapper already points to this exact script. Tell the user:
   ```
   ACE statusline is already wired.
-    Script:  <STATUSLINE_PATH>
-    Wrapper: .claude/statusline-command.sh
+    Source script : <STATUSLINE_PATH>
+    Wrapper       : .claude/statusline-command.sh
+    Settings key  : .claude/settings.local.json → statusLine.command
   No changes made.
   ```
-  Then skip to Step 5 (run the verification checks only — do not recreate files).
-- Output is `NEEDS_WIRING`: Continue to Step 4.
+  Then proceed to Step 5 (execute the verification bash block and report results — do not skip Step 5).
+- Output is `NEEDS_WIRING`: The wrapper is absent or points to a different path. Continue to Step 4.
 
 ---
 
@@ -152,16 +158,21 @@ fi
   printf '{\n  "statusLine": {\n    "command": ".claude/statusline-command.sh"\n  }\n}\n' > .claude/settings.local.json
   ```
 
-- `VALID_JSON`: Merge non-destructively (preserves all existing keys):
+- `VALID_JSON`: Merge non-destructively (preserves all existing keys). Write to a temp file first, then replace atomically:
   ```bash
   jq '.statusLine.command = ".claude/statusline-command.sh"' .claude/settings.local.json > .claude/settings.local.json.tmp \
-    && mv .claude/settings.local.json.tmp .claude/settings.local.json
+    && mv .claude/settings.local.json.tmp .claude/settings.local.json \
+    || { rm -f .claude/settings.local.json.tmp; echo "MERGE_FAILED"; }
   ```
+  If the output contains `MERGE_FAILED`, tell the user the settings file could not be updated and to check disk permissions, then **stop**.
 
-- `INVALID_JSON`: **Do not overwrite the file.** Tell the user:
+- `INVALID_JSON`: **Do not overwrite the file.** The wrapper created in Steps 4.2–4.3 has already been written. Tell the user:
   ```
   .claude/settings.local.json exists but contains invalid JSON and cannot be safely updated.
-  Please fix or delete the file manually, then run /ace-statusline-setup again.
+
+  The wrapper .claude/statusline-command.sh has been created, but the settings key
+  has NOT been set. Please fix or delete .claude/settings.local.json, then run
+  /ace-statusline-setup again to complete the wiring.
   ```
   **Stop.**
 
@@ -181,8 +192,8 @@ jq -r '.statusLine.command // "NOT_SET"' .claude/settings.local.json 2>/dev/null
 ```
 
 **Interpret results**:
-- All three show `WRAPPER_EXISTS`, `WRAPPER_EXEC`, and `.claude/statusline-command.sh` (the command value): success. Show the summary below.
-- Any line shows a failure indicator (`WRAPPER_MISSING`, `WRAPPER_NOT_EXEC`, `NOT_SET`, `SETTINGS_UNREADABLE`): tell the user which check failed and suggest running `/ace-statusline-setup` again.
+- All three show `WRAPPER_EXISTS`, `WRAPPER_EXEC`, and `.claude/statusline-command.sh` (the command value): success. Show the success summary below.
+- Any line shows a failure indicator (`WRAPPER_MISSING`, `WRAPPER_NOT_EXEC`, `NOT_SET`, `SETTINGS_UNREADABLE`): tell the user which check failed with a plain-language explanation, then suggest running `/ace-statusline-setup` again to retry.
 
 **Success summary** (fill in the resolved STATUSLINE_PATH):
 ```
@@ -201,7 +212,7 @@ This is the final step. Do not perform any additional actions after showing this
 
 ## Notes
 
-- This command is **idempotent** — safe to run multiple times. Re-running when already wired makes no changes.
-- The wrapper script is a thin shell that delegates to the installed `ace-statusline.sh`. If the ACE plugin is later updated or moved, re-run `/ace-statusline-setup` to refresh the wiring.
-- The statusline visualizes ACE session metrics (QPT score, focus, confidence, playbook health) in Claude Code's status bar.
+- This command is **idempotent** — safe to run multiple times. Re-running when already wired to the same path makes no changes.
+- If the ACE plugin is later updated or relocated, re-run `/ace-statusline-setup` to refresh the wiring; the wrapper will be overwritten with the new path.
+- The statusline visualises ACE session metrics (QPT score, focus, confidence, playbook health) in Claude Code's status bar.
 - Requires `jq` at runtime (both for this setup command and for the statusline script itself).

--- a/plugins/ace/commands/ace-statusline-setup.md
+++ b/plugins/ace/commands/ace-statusline-setup.md
@@ -1,0 +1,147 @@
+---
+description: Wire the ACE statusline into the current project
+argument-hint:
+---
+
+# ACE Statusline Setup
+
+This command wires the ACE statusline script into your current project so Claude Code displays ACE session metrics in its status bar.
+
+## Instructions for Claude
+
+When the user invokes this command, follow these steps in order:
+
+### Step 1: Check Prerequisites
+
+Use the Bash tool to check if `jq` is available:
+
+```bash
+command -v jq && echo "FOUND" || echo "NOT_FOUND"
+```
+
+**Handle results**:
+- If output contains `NOT_FOUND`: Tell the user to install `jq` (e.g., `brew install jq` on macOS, `apt install jq` on Linux) and exit. Do not proceed.
+- If output contains `FOUND`: continue to Step 2.
+
+### Step 2: Locate ace-statusline.sh
+
+Try each location in order using the Bash tool. Stop at the first one that exists.
+
+**Step 2.1**: Check plugin root (works when ACE plugin is active):
+```bash
+test -f "${CLAUDE_PLUGIN_ROOT}/scripts/ace-statusline.sh" && echo "FOUND: ${CLAUDE_PLUGIN_ROOT}/scripts/ace-statusline.sh" || echo "NOT_FOUND"
+```
+
+**Step 2.2**: If NOT_FOUND, check macOS user config:
+```bash
+test -f "$HOME/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" && echo "FOUND: $HOME/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" || echo "NOT_FOUND"
+```
+
+**Step 2.3**: If NOT_FOUND, check macOS Application Support:
+```bash
+test -f "$HOME/Library/Application Support/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" && echo "FOUND: $HOME/Library/Application Support/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" || echo "NOT_FOUND"
+```
+
+**Handle results**:
+- Use the path from the first step that returned `FOUND`. Record this as `STATUSLINE_PATH`.
+- If all three returned `NOT_FOUND`, show this error and exit:
+  ```
+  ❌ Could not find ace-statusline.sh automatically.
+
+  If you have it at a custom location, you can wire it manually:
+  1. Create .claude/statusline-command.sh with: exec "/path/to/ace-statusline.sh" "$@"
+  2. Make it executable: chmod +x .claude/statusline-command.sh
+  3. Add to .claude/settings.local.json: {"statusLine": {"command": ".claude/statusline-command.sh"}}
+  ```
+
+### Step 3: Check if Already Wired (Idempotency)
+
+Use the Bash tool to check if the statusline is already configured:
+
+```bash
+test -f ".claude/statusline-command.sh" && cat ".claude/statusline-command.sh" || echo "NOT_PRESENT"
+```
+
+**Handle results**:
+- If the output contains `NOT_PRESENT` or does not contain the `STATUSLINE_PATH` found in Step 2: proceed to Step 4.
+- If the file exists and already contains the exact `STATUSLINE_PATH` from Step 2: show a confirmation message and skip to Step 5 (verify only):
+  ```
+  ✅ ACE statusline is already wired to: {STATUSLINE_PATH}
+  No changes needed.
+  ```
+  Then jump to Step 5 to show the final status.
+
+### Step 4: Create and Configure
+
+**Step 4.1**: Ensure the `.claude` directory exists:
+```bash
+mkdir -p .claude
+```
+
+**Step 4.2**: Write `.claude/statusline-command.sh`. Replace `{STATUSLINE_PATH}` with the actual resolved path from Step 2:
+```bash
+cat > .claude/statusline-command.sh << 'SCRIPT_EOF'
+#!/usr/bin/env bash
+# ACE Statusline — wired by /ace-statusline-setup
+exec "/path/to/ace-statusline.sh" "$@"
+SCRIPT_EOF
+```
+
+**Important**: The `exec` line must use the literal resolved path, not a variable. Construct the file content with the actual path substituted.
+
+**IMPORTANT: preserve the double quotes around the path — required for paths containing spaces (e.g. ~/Library/Application Support/...).**
+
+**Step 4.3**: Make it executable:
+```bash
+chmod +x .claude/statusline-command.sh
+```
+
+**Step 4.4**: Update `.claude/settings.local.json` using `jq`.
+
+First check if the file exists:
+```bash
+test -f .claude/settings.local.json && echo "EXISTS" || echo "NOT_PRESENT"
+```
+
+- If `NOT_PRESENT`: Create it with just the statusLine key:
+  ```bash
+  echo '{"statusLine":{"command":".claude/statusline-command.sh"}}' | jq '.' > .claude/settings.local.json
+  ```
+
+- If `EXISTS`: Merge non-destructively (preserves all existing settings and sub-keys under `statusLine`):
+  ```bash
+  jq -e --arg cmd ".claude/statusline-command.sh" '.statusLine.command = $cmd' .claude/settings.local.json > .claude/settings.local.json.tmp && mv .claude/settings.local.json.tmp .claude/settings.local.json
+  ```
+
+### Step 5: Verify and Confirm
+
+Use the Bash tool to verify the wiring:
+
+```bash
+test -f .claude/statusline-command.sh && echo "WRAPPER_OK" || echo "WRAPPER_MISSING"
+test -x .claude/statusline-command.sh && echo "EXECUTABLE_OK" || echo "NOT_EXECUTABLE"
+jq -r '.statusLine.command // "NOT_SET"' .claude/settings.local.json 2>/dev/null || echo "SETTINGS_MISSING"
+```
+
+Show the user a summary:
+
+```
+✅ ACE statusline wired successfully!
+
+  Script:   {STATUSLINE_PATH}
+  Wrapper:  .claude/statusline-command.sh
+  Setting:  .claude/settings.local.json → statusLine.command
+
+Restart Claude Code for the statusline to appear in the status bar.
+```
+
+If any verification check failed, show what is missing and suggest running `/ace-statusline-setup` again.
+
+---
+
+## Notes
+
+- This command is **idempotent** — safe to run multiple times.
+- The wrapper script (`statusline-command.sh`) is a thin shell that delegates to the installed `ace-statusline.sh`.
+- The statusline visualizes ACE session metrics (QPT score, focus, confidence, playbook health) in Claude Code's status bar.
+- Requires `jq` at runtime (both for this setup command and for the statusline script itself).

--- a/plugins/ace/commands/ace-statusline-setup.md
+++ b/plugins/ace/commands/ace-statusline-setup.md
@@ -9,139 +9,199 @@ This command wires the ACE statusline script into your current project so Claude
 
 ## Instructions for Claude
 
-When the user invokes this command, follow these steps in order:
+When the user invokes this command, follow these steps **in order**. Announce each step to the user before running it (e.g., "Checking prerequisites..."). Do not skip steps or combine them out of order.
+
+---
 
 ### Step 1: Check Prerequisites
 
-Use the Bash tool to check if `jq` is available:
+Tell the user: "Checking prerequisites..."
+
+Run this single bash command:
 
 ```bash
-command -v jq && echo "FOUND" || echo "NOT_FOUND"
+command -v jq && jq --version || echo "JQ_NOT_FOUND"
 ```
 
-**Handle results**:
-- If output contains `NOT_FOUND`: Tell the user to install `jq` (e.g., `brew install jq` on macOS, `apt install jq` on Linux) and exit. Do not proceed.
-- If output contains `FOUND`: continue to Step 2.
+**Decision**:
+- Output contains `JQ_NOT_FOUND`: Tell the user jq is required and is not installed. Provide platform-specific install instructions (`brew install jq` on macOS, `apt install jq` / `yum install jq` on Linux). **Stop. Do not proceed.**
+- Output contains a jq version line: jq is present. Continue to Step 2.
+
+---
 
 ### Step 2: Locate ace-statusline.sh
 
-Try each location in order using the Bash tool. Stop at the first one that exists.
+Tell the user: "Locating ace-statusline.sh..."
 
-**Step 2.1**: Check plugin root (works when ACE plugin is active):
+Run each check in order. Stop at the first that prints `FOUND:`.
+
+**Step 2.1** — Plugin root (works when the ACE plugin is active in this session):
 ```bash
-test -f "${CLAUDE_PLUGIN_ROOT}/scripts/ace-statusline.sh" && echo "FOUND: ${CLAUDE_PLUGIN_ROOT}/scripts/ace-statusline.sh" || echo "NOT_FOUND"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/ace-statusline.sh" ]; then
+  echo "FOUND: ${CLAUDE_PLUGIN_ROOT}/scripts/ace-statusline.sh"
+else
+  echo "NOT_FOUND"
+fi
 ```
 
-**Step 2.2**: If NOT_FOUND, check macOS user config:
+**Step 2.2** — Only run this if Step 2.1 printed `NOT_FOUND`. XDG config path:
 ```bash
-test -f "$HOME/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" && echo "FOUND: $HOME/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" || echo "NOT_FOUND"
+_p="$HOME/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh"
+if [ -f "$_p" ]; then echo "FOUND: $_p"; else echo "NOT_FOUND"; fi
 ```
 
-**Step 2.3**: If NOT_FOUND, check macOS Application Support:
+**Step 2.3** — Only run this if Step 2.2 printed `NOT_FOUND`. macOS Application Support:
 ```bash
-test -f "$HOME/Library/Application Support/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" && echo "FOUND: $HOME/Library/Application Support/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" || echo "NOT_FOUND"
+_p="$HOME/Library/Application Support/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh"
+if [ -f "$_p" ]; then echo "FOUND: $_p"; else echo "NOT_FOUND"; fi
 ```
 
-**Handle results**:
-- Use the path from the first step that returned `FOUND`. Record this as `STATUSLINE_PATH`.
-- If all three returned `NOT_FOUND`, show this error and exit:
-  ```
-  ❌ Could not find ace-statusline.sh automatically.
+**Decision**:
+- At least one step printed `FOUND: <path>`: Record the path after `FOUND: ` as `STATUSLINE_PATH`. Continue to Step 3.
+- All three printed `NOT_FOUND`: Show the error block below and **stop**:
 
-  If you have it at a custom location, you can wire it manually:
-  1. Create .claude/statusline-command.sh with: exec "/path/to/ace-statusline.sh" "$@"
-  2. Make it executable: chmod +x .claude/statusline-command.sh
-  3. Add to .claude/settings.local.json: {"statusLine": {"command": ".claude/statusline-command.sh"}}
-  ```
+```
+Could not find ace-statusline.sh in any expected location.
 
-### Step 3: Check if Already Wired (Idempotency)
+Searched:
+  1. ${CLAUDE_PLUGIN_ROOT}/scripts/ace-statusline.sh  (plugin root env var)
+  2. ~/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh
+  3. ~/Library/Application Support/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh
 
-Use the Bash tool to check if the statusline is already configured:
-
-```bash
-test -f ".claude/statusline-command.sh" && cat ".claude/statusline-command.sh" || echo "NOT_PRESENT"
+To wire a custom location manually:
+  1. Create .claude/statusline-command.sh containing:
+       #!/usr/bin/env bash
+       exec "/absolute/path/to/ace-statusline.sh" "$@"
+  2. chmod +x .claude/statusline-command.sh
+  3. Add to .claude/settings.local.json: {"statusLine":{"command":".claude/statusline-command.sh"}}
 ```
 
-**Handle results**:
-- If the output contains `NOT_PRESENT` or does not contain the `STATUSLINE_PATH` found in Step 2: proceed to Step 4.
-- If the file exists and already contains the exact `STATUSLINE_PATH` from Step 2: show a confirmation message and skip to Step 5 (verify only):
+---
+
+### Step 3: Check Idempotency
+
+Tell the user: "Checking if statusline is already configured..."
+
+Run this command, substituting the literal resolved `STATUSLINE_PATH` for `<STATUSLINE_PATH>`:
+
+```bash
+grep -qF "<STATUSLINE_PATH>" .claude/statusline-command.sh 2>/dev/null && echo "ALREADY_WIRED" || echo "NEEDS_WIRING"
+```
+
+**Decision**:
+- Output is `ALREADY_WIRED`: The statusline is already pointing to this exact script. Tell the user:
   ```
-  ✅ ACE statusline is already wired to: {STATUSLINE_PATH}
-  No changes needed.
+  ACE statusline is already wired.
+    Script:  <STATUSLINE_PATH>
+    Wrapper: .claude/statusline-command.sh
+  No changes made.
   ```
-  Then jump to Step 5 to show the final status.
+  Then skip to Step 5 (run the verification checks only — do not recreate files).
+- Output is `NEEDS_WIRING`: Continue to Step 4.
+
+---
 
 ### Step 4: Create and Configure
 
-**Step 4.1**: Ensure the `.claude` directory exists:
+Tell the user: "Wiring statusline..."
+
+**Step 4.1** — Ensure `.claude` directory exists:
 ```bash
 mkdir -p .claude
 ```
 
-**Step 4.2**: Write `.claude/statusline-command.sh`. Replace `{STATUSLINE_PATH}` with the actual resolved path from Step 2:
-```bash
-cat > .claude/statusline-command.sh << 'SCRIPT_EOF'
+**Step 4.2** — Write `.claude/statusline-command.sh`.
+
+CRITICAL: You must write the file with the literal resolved path substituted into the `exec` line. Do NOT write the placeholder text `<STATUSLINE_PATH>` or any variable reference. The exec line must be a hard-coded absolute path string.
+
+For example, if `STATUSLINE_PATH` resolved to `/home/alice/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh`, the file must contain exactly:
+
+```
 #!/usr/bin/env bash
 # ACE Statusline — wired by /ace-statusline-setup
-exec "/path/to/ace-statusline.sh" "$@"
-SCRIPT_EOF
+exec "/home/alice/.config/claude-code/marketplaces/ce-dot-net-marketplace/plugins/ace/scripts/ace-statusline.sh" "$@"
 ```
 
-**Important**: The `exec` line must use the literal resolved path, not a variable. Construct the file content with the actual path substituted.
+Construct and run a bash command that writes this file with the actual resolved path. Use double quotes around the path in the `exec` line — this is required for paths containing spaces (e.g. paths under `~/Library/Application Support/`).
 
-**IMPORTANT: preserve the double quotes around the path — required for paths containing spaces (e.g. ~/Library/Application Support/...).**
+A correct approach using printf:
+```bash
+printf '#!/usr/bin/env bash\n# ACE Statusline — wired by /ace-statusline-setup\nexec "%s" "$@"\n' "<STATUSLINE_PATH>" > .claude/statusline-command.sh
+```
+Replace `<STATUSLINE_PATH>` with the literal resolved path before running.
 
-**Step 4.3**: Make it executable:
+**Step 4.3** — Make it executable:
 ```bash
 chmod +x .claude/statusline-command.sh
 ```
 
-**Step 4.4**: Update `.claude/settings.local.json` using `jq`.
+**Step 4.4** — Update `.claude/settings.local.json`.
 
-First check if the file exists:
+First, check whether the file exists and whether it is valid JSON:
 ```bash
-test -f .claude/settings.local.json && echo "EXISTS" || echo "NOT_PRESENT"
+if [ -f .claude/settings.local.json ]; then
+  jq -e . .claude/settings.local.json > /dev/null 2>&1 && echo "VALID_JSON" || echo "INVALID_JSON"
+else
+  echo "NOT_PRESENT"
+fi
 ```
 
-- If `NOT_PRESENT`: Create it with just the statusLine key:
+**Decision**:
+- `NOT_PRESENT`: Create the file:
   ```bash
-  echo '{"statusLine":{"command":".claude/statusline-command.sh"}}' | jq '.' > .claude/settings.local.json
+  printf '{\n  "statusLine": {\n    "command": ".claude/statusline-command.sh"\n  }\n}\n' > .claude/settings.local.json
   ```
 
-- If `EXISTS`: Merge non-destructively (preserves all existing settings and sub-keys under `statusLine`):
+- `VALID_JSON`: Merge non-destructively (preserves all existing keys):
   ```bash
-  jq -e --arg cmd ".claude/statusline-command.sh" '.statusLine.command = $cmd' .claude/settings.local.json > .claude/settings.local.json.tmp && mv .claude/settings.local.json.tmp .claude/settings.local.json
+  jq '.statusLine.command = ".claude/statusline-command.sh"' .claude/settings.local.json > .claude/settings.local.json.tmp \
+    && mv .claude/settings.local.json.tmp .claude/settings.local.json
   ```
 
-### Step 5: Verify and Confirm
+- `INVALID_JSON`: **Do not overwrite the file.** Tell the user:
+  ```
+  .claude/settings.local.json exists but contains invalid JSON and cannot be safely updated.
+  Please fix or delete the file manually, then run /ace-statusline-setup again.
+  ```
+  **Stop.**
 
-Use the Bash tool to verify the wiring:
+---
+
+### Step 5: Verify and Report
+
+Tell the user: "Verifying..."
+
+Run all checks in one bash command:
 
 ```bash
-test -f .claude/statusline-command.sh && echo "WRAPPER_OK" || echo "WRAPPER_MISSING"
-test -x .claude/statusline-command.sh && echo "EXECUTABLE_OK" || echo "NOT_EXECUTABLE"
-jq -r '.statusLine.command // "NOT_SET"' .claude/settings.local.json 2>/dev/null || echo "SETTINGS_MISSING"
+echo "=== VERIFY ==="
+test -f .claude/statusline-command.sh   && echo "WRAPPER_EXISTS"   || echo "WRAPPER_MISSING"
+test -x .claude/statusline-command.sh   && echo "WRAPPER_EXEC"     || echo "WRAPPER_NOT_EXEC"
+jq -r '.statusLine.command // "NOT_SET"' .claude/settings.local.json 2>/dev/null || echo "SETTINGS_UNREADABLE"
 ```
 
-Show the user a summary:
+**Interpret results**:
+- All three show `WRAPPER_EXISTS`, `WRAPPER_EXEC`, and `.claude/statusline-command.sh` (the command value): success. Show the summary below.
+- Any line shows a failure indicator (`WRAPPER_MISSING`, `WRAPPER_NOT_EXEC`, `NOT_SET`, `SETTINGS_UNREADABLE`): tell the user which check failed and suggest running `/ace-statusline-setup` again.
 
+**Success summary** (fill in the resolved STATUSLINE_PATH):
 ```
-✅ ACE statusline wired successfully!
+ACE statusline wired successfully.
 
-  Script:   {STATUSLINE_PATH}
-  Wrapper:  .claude/statusline-command.sh
-  Setting:  .claude/settings.local.json → statusLine.command
+  Source script : <STATUSLINE_PATH>
+  Wrapper       : .claude/statusline-command.sh
+  Settings key  : .claude/settings.local.json → statusLine.command
 
 Restart Claude Code for the statusline to appear in the status bar.
 ```
 
-If any verification check failed, show what is missing and suggest running `/ace-statusline-setup` again.
+This is the final step. Do not perform any additional actions after showing this summary.
 
 ---
 
 ## Notes
 
-- This command is **idempotent** — safe to run multiple times.
-- The wrapper script (`statusline-command.sh`) is a thin shell that delegates to the installed `ace-statusline.sh`.
+- This command is **idempotent** — safe to run multiple times. Re-running when already wired makes no changes.
+- The wrapper script is a thin shell that delegates to the installed `ace-statusline.sh`. If the ACE plugin is later updated or moved, re-run `/ace-statusline-setup` to refresh the wiring.
 - The statusline visualizes ACE session metrics (QPT score, focus, confidence, playbook health) in Claude Code's status bar.
 - Requires `jq` at runtime (both for this setup command and for the statusline script itself).

--- a/plugins/ace/docs/guides/README.md
+++ b/plugins/ace/docs/guides/README.md
@@ -12,6 +12,11 @@ User-facing documentation for setup, configuration, and troubleshooting.
 
 - **[CONFIGURATION.md](./CONFIGURATION.md)** - Configuration options, environment variables, and customization
 
+### Status Line
+
+- **[STATUSLINE-TUTORIAL.md](./STATUSLINE-TUTORIAL.md)** - Getting started with the ACE status line (install, first run, reading the output)
+- **[STATUSLINE.md](./STATUSLINE.md)** - Component reference: formulas, ranges, and interpretation for every metric
+
 ### Troubleshooting
 
 - **[TROUBLESHOOTING.md](./TROUBLESHOOTING.md)** - Common issues, error messages, and solutions

--- a/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
+++ b/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
@@ -138,21 +138,6 @@ Each row is a sparkline showing ACE hook event density over time. The height and
 
 The counts above the sparklines (15m, 60m, 1d, 1w) are the total number of events in each window.
 
-### CC section
-
-```
-◉ CTX: ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 28%
-▸ Model: claude-sonnet-4-5  Cost: $0.12  Time: 3m42s  CC-Lines: +127/-34
-```
-
-The CC section is Claude Code's own session information. It is separate from ACE metrics and is always shown regardless of ACE data availability.
-
-- **CTX bar** — context window usage (green = plenty of room, red = approaching limit).
-- **Model** — the model that responded.
-- **Cost** — cumulative API cost for the session.
-- **Time** — total wall time since session start.
-- **CC-Lines** — lines added/removed by Claude Code across the session.
-
 ---
 
 ## 6. Why All Zeros? (Common Confusion)

--- a/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
+++ b/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
@@ -131,7 +131,7 @@ If you see `blind spot`, don't panic — it just means ACE hasn't learned this d
 ♦ PLAYBOOK: 148 pts  Ratio: 91% healthy  Domains: 12
 ```
 
-The total number of patterns in your playbook, the percentage rated helpful versus harmful, and how many distinct domains are covered. These values come from `ace-cli status` and are cached for 60 seconds (see Section 7 for why). A healthy ratio above 85% and growing domain count is a good sign that your playbook is maturing.
+The total number of patterns in your playbook, the percentage rated helpful versus harmful, and how many distinct domains are covered. These values come from `ace-cli status` and are cached for 60 seconds (see Section 7 for why). A healthy ratio of 80% or above and growing domain count is a good sign that your playbook is maturing.
 
 ### ▪ USAGE bar
 

--- a/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
+++ b/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
@@ -1,0 +1,273 @@
+# Getting Started with the ACE Statusline
+
+**Audience**: ACE is already installed. You want to add the live statusline to your Claude Code setup.
+
+**Time**: ~5 minutes
+
+---
+
+## 1. What is the ACE Statusline?
+
+The ACE statusline is a live status bar that appears inside Claude Code after each assistant response. It shows ACE effectiveness metrics for your current session: how focused Claude is being, how well its patterns matched your work, and how actively your playbook is learning.
+
+The display adapts to your terminal width across four responsive modes:
+
+| Mode | Width | What you see |
+|---|---|---|
+| nano | < 40 cols | QPT score only |
+| micro | 40–59 cols | QPT + Focus + Confidence |
+| mini | 60–99 cols | QPT + all metrics + playbook health |
+| normal | 100+ cols | Full dashboard with sparkline activity charts |
+
+A terminal width of 100 columns or more is recommended to see the full dashboard.
+
+---
+
+## 2. Prerequisites
+
+Before setup, confirm you have:
+
+**jq** — required at runtime by the statusline script:
+```bash
+# macOS
+brew install jq
+
+# Debian / Ubuntu
+sudo apt install jq
+
+# Verify
+jq --version
+```
+
+**ace-cli** — installed and authenticated. If you haven't done this yet, follow the [Installation Guide](INSTALL.md) first.
+
+```bash
+ace-cli --version
+# Should show: >= 3.10.3
+```
+
+---
+
+## 3. Install
+
+Run this slash command from inside Claude Code in your project:
+
+```
+/ace-statusline-setup
+```
+
+That's it. The command does three things automatically:
+
+1. Locates `ace-statusline.sh` in your plugin installation.
+2. Creates `.claude/statusline-command.sh` — a thin wrapper that Claude Code calls after each response.
+3. Adds the `statusLine` key to `.claude/settings.local.json` pointing at that wrapper.
+
+After it completes, **restart Claude Code** for the statusline to appear.
+
+> The command is idempotent — safe to run again if something changes or needs re-wiring.
+
+---
+
+## 4. First Run
+
+After restarting Claude Code and opening your project, you may briefly see one of two placeholder states before any prompts are submitted:
+
+**`ACE: awaiting session`** — Claude Code has not yet provided a session ID. This is a normal state during startup; it resolves within a second or two as the session initializes.
+
+**`ACE: no data`** — The session ID is present, but the file `.claude/data/logs/ace-relevance.jsonl` does not exist yet. This means no ACE hooks have fired yet in this project. After your first prompt completes, the file is created and the statusline switches to showing real data.
+
+On your very first prompt after setup, all metrics will show zeros. This is expected — see the next section for why.
+
+---
+
+## 5. Reading the Output
+
+In **normal** mode (terminal width >= 100 cols) the statusline renders as a multi-line dashboard. Here is what each component means:
+
+### QPT — Quality Per Task
+
+```
+◉ QPT: 72  Focus: 85%  Conf: 60%  Inj: 40%  Terrain: familiar
+```
+
+**QPT** (Quality Per Task) is a composite score from 0–100 representing how effectively ACE helped Claude during this session. It is a weighted blend of Focus, Confidence, learning rate, and task success rate.
+
+Color interpretation:
+- Green (>= 70) — ACE is contributing well; patterns are being found and used.
+- Yellow (40–69) — partial contribution; some patterns matched but usage is moderate.
+- Red (< 40) — low contribution; playbook may lack patterns for this domain.
+
+**Focus** — the percentage of Claude's tool calls that were state-changing (writes, edits, creates) versus reads. Higher focus generally means Claude is executing rather than exploring.
+
+**Conf** — average confidence of pattern matches returned by the ACE search on the most recent UserPromptSubmit. A value of 0% on the first prompt is expected (see Section 6).
+
+**Inj** — the percentage of injected patterns that Claude actually used (referenced in tool calls). Higher injection utilization means patterns are relevant and actionable.
+
+**Terrain** — how well the current session's domains overlap with your playbook's strongest domains:
+- `familiar` (green) — >= 70% overlap; you are working in well-covered territory.
+- `exploring` (yellow) — 30–69% overlap; some patterns exist but coverage is partial.
+- `blind spot` (red) — < 30% overlap; ACE has few patterns for this domain yet.
+
+### PLAYBOOK line
+
+```
+♦ PLAYBOOK: 148 pts  Ratio: 91% healthy  Domains: 12
+```
+
+Shows the total number of patterns in your playbook, the percentage rated helpful versus harmful, and how many distinct domains are covered. These values come from `ace-cli status` and are cached for 60 seconds (see Section 7).
+
+### USAGE bar
+
+```
+▪ USAGE:    ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 47%  (70/150)
+```
+
+The USAGE bar shows your plan's pattern consumption. It only appears when your account has a pattern limit (i.e., a paid plan with a cap). If you are on an unlimited plan or the limit is not set, this line is hidden.
+
+### LEARNING sparklines
+
+```
+✿ LEARNING:  15m: 3 │ 60m: 8 │ 1d: 22 │ 1w: 97
+├─ 15m: ▁▂▃▄▅
+├─ 60m: ▂▃▄▅▃▂▁▂▃▄▅▃
+├── 1d: ▃▄▅▄▃▂▁▂▃▄▅▄▃▂▁▃▄▅▄▃▄▄▅
+└── 1w: ▂▄▅▄▃
+```
+
+Each row is a sparkline showing ACE hook event density over time. The height and color of each bar encodes relative activity: tall green bars mean high activity, short red bars mean low activity relative to the window's peak.
+
+The counts above the sparklines (15m, 60m, 1d, 1w) are the total number of events in each window.
+
+### CC section
+
+```
+◉ CTX: ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 28%
+▸ Model: claude-sonnet-4-5  Cost: $0.12  Time: 3m42s  CC-Lines: +127/-34
+```
+
+The CC section is Claude Code's own session information. It is separate from ACE metrics and is always shown regardless of ACE data availability.
+
+- **CTX bar** — context window usage (green = plenty of room, red = approaching limit).
+- **Model** — the model that responded.
+- **Cost** — cumulative API cost for the session.
+- **Time** — total wall time since session start.
+- **CC-Lines** — lines added/removed by Claude Code across the session.
+
+---
+
+## 6. Why All Zeros? (Common Confusion)
+
+If you run a prompt and the statusline still shows zeros, here is why and what to do.
+
+### Session scope
+
+All ACE metrics accumulate within a single Claude Code session and reset when you restart. The statusline aggregates events from the current session only — it does not pull history from previous sessions.
+
+### Per-prompt scope
+
+Each time you submit a prompt, the `UserPromptSubmit` hook fires, searches the playbook, and writes one `search` event to `ace-relevance.jsonl`. When the task completes, the `Stop` hook fires and writes one `execution` event. The statusline reads and aggregates all events for the current session.
+
+### First prompt: Conf shows 0
+
+`Conf` is the average confidence from the most recent search event. On the very first prompt of a fresh session, the search runs as part of `UserPromptSubmit` — but the statusline updates after `Stop`, which is at the end of the response. So after your first prompt completes, Conf will be populated and visible on the statusline. It is only 0 before any prompt has been submitted.
+
+### "ACE: no data" — hooks have not fired yet
+
+If the statusline shows `ACE: no data` after you submit a prompt, it means `.claude/data/logs/ace-relevance.jsonl` still does not exist. This means the ACE hooks are not running. Run `/ace-test` to verify your hook configuration and check that the hooks are wired correctly.
+
+### What to do to see real data
+
+1. Submit a prompt that does some work (e.g., "explain this codebase" or "implement X").
+2. Wait for Claude to finish responding — the Stop hook fires at the end.
+3. The next statusline update will show populated metrics.
+
+---
+
+## 7. Update Timing
+
+Understanding when the statusline refreshes helps set expectations:
+
+**Session metrics (QPT, Focus, Conf, Inj, Terrain)** — refresh after every assistant response. The `Stop` hook writes a new execution event, and the statusline reads `ace-relevance.jsonl` fresh each time (no in-process caching). Expect a brief delay between Claude's final message and the statusline updating.
+
+**Playbook health (PLAYBOOK line)** — uses a 60-second background cache stored at `/tmp/ace-statusline-cache-*.json`. This is intentional: fetching playbook stats requires a network call to the ACE server, which would add visible latency on every response. Instead, the statusline renders from the cache immediately and refreshes the cache in the background when it is stale. Values are always within 60 seconds of the latest server state.
+
+**First-time playbook fetch** — on a fresh session with no cache file, the PLAYBOOK line shows `--` until the background refresh completes (typically under 5 seconds). Subsequent updates use the cached file.
+
+---
+
+## 8. Troubleshooting
+
+### Statusline not appearing after restart
+
+Check that `settings.local.json` has the `statusLine` key:
+
+```bash
+cat .claude/settings.local.json | jq '.statusLine'
+```
+
+Expected output:
+```json
+{
+  "command": ".claude/statusline-command.sh"
+}
+```
+
+If the key is missing or the file does not exist, run `/ace-statusline-setup` again.
+
+Also verify the wrapper script is executable:
+```bash
+ls -la .claude/statusline-command.sh
+```
+
+It should have execute permission (`-rwxr-xr-x`). If not:
+```bash
+chmod +x .claude/statusline-command.sh
+```
+
+### All zeros after multiple prompts
+
+Check that the relevance log file exists:
+```bash
+ls .claude/data/logs/ace-relevance.jsonl
+```
+
+If the file is missing, ACE hooks have not written any data. Run `/ace-test` to verify hooks are wiring up correctly.
+
+If the file exists but metrics stay at zero, inspect the content:
+```bash
+tail -5 .claude/data/logs/ace-relevance.jsonl | jq '.'
+```
+
+You should see objects with `event: "search"` and `event: "execution"` entries that have your current `session_id`.
+
+### Statusline shows "ACE: no data"
+
+This means `ace-relevance.jsonl` does not exist in the current project directory. The most common cause is that the ACE hooks have not run yet. Steps to verify:
+
+1. Run `/ace-test` — this will check that hooks are firing.
+2. Submit a real prompt and wait for it to complete.
+3. Check that the file was created: `ls .claude/data/logs/ace-relevance.jsonl`.
+
+### Slow startup / PLAYBOOK shows "--"
+
+The `--` value on the PLAYBOOK line means the cache is empty and the background fetch is in progress. This is normal on the first statusline render of a session. Wait a few seconds and submit another prompt — the next render will use the populated cache.
+
+If the PLAYBOOK line never populates, verify `ace-cli` can reach the server:
+```bash
+ace-cli status --json
+```
+
+---
+
+## Next Steps
+
+Once the statusline is running, use it to understand how ACE is performing in your project:
+
+- **Low QPT / red score** — your playbook may not yet have patterns for the domains you are working in. Run `/ace-bootstrap` to generate initial patterns from your codebase.
+- **Terrain shows "blind spot"** — submit a few tasks and let the Stop hook capture learnings. Playbook coverage grows automatically as you work.
+- **Inj% near zero but Conf% is high** — patterns are being found but not referenced. Check if the patterns are specific enough to your codebase with `/ace-patterns`.
+
+For more on the ACE plugin:
+- [Installation Guide](INSTALL.md)
+- [Configuration Guide](CONFIGURATION.md)
+- [Troubleshooting Guide](TROUBLESHOOTING.md)

--- a/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
+++ b/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
@@ -193,6 +193,8 @@ Understanding when the statusline refreshes helps set expectations:
 
 **First-time playbook fetch** — on a fresh session with no cache file, the PLAYBOOK line shows `--` until the background refresh completes (typically under 5 seconds). Subsequent updates use the cached file.
 
+**Platform behavior** — Claude Code runs the statusline command after every assistant response, when the permission mode changes, and when vim mode toggles. Updates are debounced at 300ms (rapid changes batch into a single run). If a new update triggers while the script is still running, the in-flight execution is cancelled. The statusline does **not** refresh on a time interval while Claude Code is idle — if you want to see updated playbook counts without sending a message, there is an open feature request for a `refreshIntervalSeconds` option ([issue #5685](https://github.com/anthropics/claude-code/issues/5685)).
+
 ---
 
 ## 8. Troubleshooting

--- a/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
+++ b/plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md
@@ -6,9 +6,11 @@
 
 ---
 
-## 1. What is the ACE Statusline?
+## 🎯 What is the ACE Statusline?
 
-The ACE statusline is a live status bar that appears inside Claude Code after each assistant response. It shows ACE effectiveness metrics for your current session: how focused Claude is being, how well its patterns matched your work, and how actively your playbook is learning.
+Without the statusline, ACE is a black box. Patterns get retrieved, tasks get executed, learning gets captured — but you have no visibility into whether any of it is actually working for you. Is ACE finding relevant patterns, or returning noise? Is Claude using what it found, or ignoring it? Is your playbook growing?
+
+The statusline answers those questions after every single response. It appears inside Claude Code as a live dashboard showing ACE effectiveness metrics for your current session: how focused Claude is being, how confidently patterns matched your work, and whether your playbook is accumulating knowledge in the domains you actually use.
 
 The display adapts to your terminal width across four responsive modes:
 
@@ -19,11 +21,11 @@ The display adapts to your terminal width across four responsive modes:
 | mini | 60–99 cols | QPT + all metrics + playbook health |
 | normal | 100+ cols | Full dashboard with sparkline activity charts |
 
-A terminal width of 100 columns or more is recommended to see the full dashboard.
+A terminal width of 100 columns or more is recommended to see the full dashboard. The rest of this tutorial assumes normal mode.
 
 ---
 
-## 2. Prerequisites
+## 📋 Prerequisites
 
 Before setup, confirm you have:
 
@@ -48,7 +50,7 @@ ace-cli --version
 
 ---
 
-## 3. Install
+## 🚀 Install
 
 Run this slash command from inside Claude Code in your project:
 
@@ -68,63 +70,78 @@ After it completes, **restart Claude Code** for the statusline to appear.
 
 ---
 
-## 4. First Run
+## 🔍 First Run
 
 After restarting Claude Code and opening your project, you may briefly see one of two placeholder states before any prompts are submitted:
 
-**`ACE: awaiting session`** — Claude Code has not yet provided a session ID. This is a normal state during startup; it resolves within a second or two as the session initializes.
+**`ACE: awaiting session`** — Claude Code has not yet provided a session ID. This is a normal startup state; it resolves within a second or two as the session initializes.
 
-**`ACE: no data`** — The session ID is present, but the file `.claude/data/logs/ace-relevance.jsonl` does not exist yet. This means no ACE hooks have fired yet in this project. After your first prompt completes, the file is created and the statusline switches to showing real data.
+**`ACE: no data`** — The session ID is present, but `.claude/data/logs/ace-relevance.jsonl` does not exist yet. This means no ACE hooks have fired in this project. After your first prompt completes, the file is created and the statusline switches to showing real data.
 
-On your very first prompt after setup, all metrics will show zeros. This is expected — see the next section for why.
+On your very first prompt after setup, all metrics will show zeros. This is expected — Section 6 explains exactly what is happening and why it resolves on its own.
 
 ---
 
-## 5. Reading the Output
+## 📊 Reading the Output
 
-In **normal** mode (terminal width >= 100 cols) the statusline renders as a multi-line dashboard. Here is what each component means:
+In **normal** mode (terminal width >= 100 cols) the statusline renders as a multi-line dashboard. Here is a complete example of what you will see after a productive session:
 
-### QPT — Quality Per Task
+```
+◉ QPT: 72  Focus: 85%  Conf: 60%  Inj: 40%  Terrain: familiar
+♦ PLAYBOOK: 148 pts  Ratio: 91% healthy  Domains: 12
+▪ USAGE:    ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 47%  (70/150)
+✿ LEARNING:  15m: 3 │ 60m: 8 │ 1d: 22 │ 1w: 97
+├─ 15m: ▁▂▃▄▅
+├─ 60m: ▂▃▄▅▃▂▁▂▃▄▅▃
+├── 1d: ▃▄▅▄▃▂▁▂▃▄▅▄▃▂▁▃▄▅▄▃▄▄▅
+└── 1w: ▂▄▅▄▃
+```
+
+Let's walk through each line.
+
+### ◉ QPT — Quality Per Task
 
 ```
 ◉ QPT: 72  Focus: 85%  Conf: 60%  Inj: 40%  Terrain: familiar
 ```
 
-**QPT** (Quality Per Task) is a composite score from 0–100 representing how effectively ACE helped Claude during this session. It is a weighted blend of Focus, Confidence, learning rate, and task success rate.
+**QPT** (Quality Per Task) is a composite score from 0–100 representing how effectively ACE helped Claude during this session. It is a weighted blend of Focus, Confidence, learning rate, and task success rate. Think of it as a single health number for the session: above 70 means ACE is pulling its weight, below 40 means your playbook probably lacks patterns for the domains you are working in.
 
 Color interpretation:
-- Green (>= 70) — ACE is contributing well; patterns are being found and used.
-- Yellow (40–69) — partial contribution; some patterns matched but usage is moderate.
-- Red (< 40) — low contribution; playbook may lack patterns for this domain.
+- ✅ Green (>= 70) — ACE is contributing well; patterns are being found and used.
+- 🟡 Yellow (40–69) — partial contribution; some patterns matched but usage is moderate.
+- 🔴 Red (< 40) — low contribution; playbook may lack patterns for this domain.
 
-**Focus** — the percentage of Claude's tool calls that were state-changing (writes, edits, creates) versus reads. Higher focus generally means Claude is executing rather than exploring.
+**Focus** — the percentage of Claude's tool calls that were state-changing (writes, edits, creates) versus reads. Higher focus generally means Claude is executing rather than exploring. A low Focus score on a simple implementation task can signal that Claude is spending more time reading the codebase than making changes — worth noticing if it's a pattern.
 
-**Conf** — average confidence of pattern matches returned by the ACE search on the most recent UserPromptSubmit. A value of 0% on the first prompt is expected (see Section 6).
+**Conf** — average confidence of pattern matches returned by the ACE search on the most recent `UserPromptSubmit`. This tells you how well your playbook's patterns aligned with the prompt semantically. High Conf means ACE found strong matches; low Conf means the domain may be undercovered. A value of 0% on the first prompt is expected (see Section 6).
 
-**Inj** — the percentage of injected patterns that Claude actually used (referenced in tool calls). Higher injection utilization means patterns are relevant and actionable.
+**Inj** — the percentage of injected patterns that Claude actually used (referenced in tool calls). This is the signal for pattern *quality*, not just retrieval. If Conf is high but Inj is near zero, ACE is finding patterns but they are too generic to be actionable — run `/ace-patterns` to inspect what's being injected.
 
 **Terrain** — how well the current session's domains overlap with your playbook's strongest domains:
 - `familiar` (green) — >= 70% overlap; you are working in well-covered territory.
 - `exploring` (yellow) — 30–69% overlap; some patterns exist but coverage is partial.
 - `blind spot` (red) — < 30% overlap; ACE has few patterns for this domain yet.
 
-### PLAYBOOK line
+If you see `blind spot`, don't panic — it just means ACE hasn't learned this domain yet. Your next Stop hook will start building that coverage automatically.
+
+### ♦ PLAYBOOK line
 
 ```
 ♦ PLAYBOOK: 148 pts  Ratio: 91% healthy  Domains: 12
 ```
 
-Shows the total number of patterns in your playbook, the percentage rated helpful versus harmful, and how many distinct domains are covered. These values come from `ace-cli status` and are cached for 60 seconds (see Section 7).
+The total number of patterns in your playbook, the percentage rated helpful versus harmful, and how many distinct domains are covered. These values come from `ace-cli status` and are cached for 60 seconds (see Section 7 for why). A healthy ratio above 85% and growing domain count is a good sign that your playbook is maturing.
 
-### USAGE bar
+### ▪ USAGE bar
 
 ```
 ▪ USAGE:    ⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁⛁ 47%  (70/150)
 ```
 
-The USAGE bar shows your plan's pattern consumption. It only appears when your account has a pattern limit (i.e., a paid plan with a cap). If you are on an unlimited plan or the limit is not set, this line is hidden.
+Your plan's pattern consumption against its cap. This line only appears when your account has a pattern limit (i.e., a paid plan with a cap). If you are on an unlimited plan or the limit is not set, this line is hidden.
 
-### LEARNING sparklines
+### ✿ LEARNING sparklines
 
 ```
 ✿ LEARNING:  15m: 3 │ 60m: 8 │ 1d: 22 │ 1w: 97
@@ -134,59 +151,74 @@ The USAGE bar shows your plan's pattern consumption. It only appears when your a
 └── 1w: ▂▄▅▄▃
 ```
 
-Each row is a sparkline showing ACE hook event density over time. The height and color of each bar encodes relative activity: tall green bars mean high activity, short red bars mean low activity relative to the window's peak.
-
-The counts above the sparklines (15m, 60m, 1d, 1w) are the total number of events in each window.
+Each row is a sparkline showing ACE hook event density over time. The height and color of each bar encodes relative activity: tall green bars mean high activity, short red bars mean low activity relative to the window's peak. The counts above (15m, 60m, 1d, 1w) are the total number of events in each window. A flat or empty 1w sparkline on a project you've been using for days is a signal to check whether your Stop hook is firing — that's where learning events originate.
 
 ---
 
-## 6. Why All Zeros? (Common Confusion)
+## 🤔 Why All Zeros? (Common Confusion)
 
-If you run a prompt and the statusline still shows zeros, here is why and what to do.
+You just ran a task. Claude responded. The statusline updated. Everything is zero.
 
-### Session scope
+Here is exactly what happened — and why it resolves on its own.
 
-All ACE metrics accumulate within a single Claude Code session and reset when you restart. The statusline aggregates events from the current session only — it does not pull history from previous sessions.
+### What the statusline is actually reading
 
-### Per-prompt scope
+The statusline reads `.claude/data/logs/ace-relevance.jsonl`, a log file that ACE hooks write to during your session. Every metric on the dashboard is derived from events in that file. No events yet means all zeros, every time.
 
-Each time you submit a prompt, the `UserPromptSubmit` hook fires, searches the playbook, and writes one `search` event to `ace-relevance.jsonl`. When the task completes, the `Stop` hook fires and writes one `execution` event. The statusline reads and aggregates all events for the current session.
+Two hooks write to that file:
 
-### First prompt: Conf shows 0
+- **`UserPromptSubmit`** fires when you submit a prompt. It searches the playbook and writes a `search` event containing the confidence score of each match.
+- **`Stop`** fires when Claude finishes responding. It writes an `execution` event containing what tool calls were made, which patterns were used, and what domains were active.
 
-`Conf` is the average confidence from the most recent search event. On the very first prompt of a fresh session, the search runs as part of `UserPromptSubmit` — but the statusline updates after `Stop`, which is at the end of the response. So after your first prompt completes, Conf will be populated and visible on the statusline. It is only 0 before any prompt has been submitted.
+The statusline updates after `Stop` — so both events need to exist before you see meaningful numbers.
 
-### "ACE: no data" — hooks have not fired yet
+### All metrics are scoped to the current session
 
-If the statusline shows `ACE: no data` after you submit a prompt, it means `.claude/data/logs/ace-relevance.jsonl` still does not exist. This means the ACE hooks are not running. Run `/ace-test` to verify your hook configuration and check that the hooks are wired correctly.
+ACE metrics accumulate within a single Claude Code session and reset when you restart. The statusline aggregates only the events from your current session — it does not pull history from previous sessions. On session start, the slate is clean.
 
-### What to do to see real data
+### The first-prompt sequence
 
-1. Submit a prompt that does some work (e.g., "explain this codebase" or "implement X").
-2. Wait for Claude to finish responding — the Stop hook fires at the end.
-3. The next statusline update will show populated metrics.
+Here is the exact sequence on your very first prompt:
+
+1. You submit a prompt → `UserPromptSubmit` fires, searches the playbook, writes a `search` event.
+2. Claude responds → `Stop` fires, writes an `execution` event.
+3. Statusline updates → now it has both events and can calculate metrics.
+
+So after your first prompt completes, Conf will be populated and QPT will have data. The zeros you see immediately after submitting are correct — the Stop hook hasn't fired yet.
+
+### "ACE: no data" means hooks haven't run at all
+
+If the statusline shows `ACE: no data` even after a prompt completes, the log file was never created, which means the ACE hooks are not running. Run `/ace-test` to check your hook configuration and verify the hooks are wired correctly.
+
+### What to do
+
+Submit a prompt that does real work — something like "explain this codebase" or "implement X". Wait for Claude to finish responding completely. The next statusline update will show populated metrics.
 
 ---
 
-## 7. Update Timing
+## ⏱️ Update Timing
 
-Understanding when the statusline refreshes helps set expectations:
+Knowing when each piece of the dashboard refreshes helps you trust what you are reading.
 
-**Session metrics (QPT, Focus, Conf, Inj, Terrain)** — refresh after every assistant response. The `Stop` hook writes a new execution event, and the statusline reads `ace-relevance.jsonl` fresh each time (no in-process caching). Expect a brief delay between Claude's final message and the statusline updating.
+**Session metrics (QPT, Focus, Conf, Inj, Terrain)** refresh after every assistant response. The `Stop` hook writes a new execution event, and the statusline reads `ace-relevance.jsonl` fresh each time — no in-process caching. Expect a brief delay between Claude's final message and the statusline updating; that's the Stop hook running.
 
-**Playbook health (PLAYBOOK line)** — uses a 60-second background cache stored at `/tmp/ace-statusline-cache-*.json`. This is intentional: fetching playbook stats requires a network call to the ACE server, which would add visible latency on every response. Instead, the statusline renders from the cache immediately and refreshes the cache in the background when it is stale. Values are always within 60 seconds of the latest server state.
+**Playbook health (PLAYBOOK line)** uses a 60-second background cache stored at `/tmp/ace-statusline-cache-*.json`. This is intentional: fetching playbook stats requires a network call to the ACE server, which would add visible latency on every single response. Instead, the statusline renders from the cache immediately and refreshes it in the background when stale. The values you see are always within 60 seconds of the latest server state.
 
 **First-time playbook fetch** — on a fresh session with no cache file, the PLAYBOOK line shows `--` until the background refresh completes (typically under 5 seconds). Subsequent updates use the cached file.
 
-**Platform behavior** — Claude Code runs the statusline command after every assistant response, when the permission mode changes, and when vim mode toggles. Updates are debounced at 300ms (rapid changes batch into a single run). If a new update triggers while the script is still running, the in-flight execution is cancelled. The statusline does **not** refresh on a time interval while Claude Code is idle — if you want to see updated playbook counts without sending a message, there is an open feature request for a `refreshIntervalSeconds` option ([issue #5685](https://github.com/anthropics/claude-code/issues/5685)).
+**Platform behavior** — Claude Code runs the statusline command after every assistant response, when the permission mode changes, and when vim mode toggles. Updates are debounced at 300ms (rapid changes batch into a single run). If a new update triggers while the script is still running, the in-flight execution is cancelled. The statusline does **not** refresh on a time interval while Claude Code is idle — if you want updated playbook counts without sending a message, there is an open feature request for a `refreshIntervalSeconds` option ([issue #5685](https://github.com/anthropics/claude-code/issues/5685)).
 
 ---
 
-## 8. Troubleshooting
+## 🔧 Troubleshooting
 
 ### Statusline not appearing after restart
 
-Check that `settings.local.json` has the `statusLine` key:
+**Symptom**: You restarted Claude Code after running `/ace-statusline-setup` and see no statusline at all.
+
+**What's happening**: Claude Code won't render a statusline unless the `statusLine` key exists in `settings.local.json` pointing to an executable script. Either the setup didn't complete, or the file isn't executable.
+
+**Fix**: Check that the key is present:
 
 ```bash
 cat .claude/settings.local.json | jq '.statusLine'
@@ -211,48 +243,63 @@ It should have execute permission (`-rwxr-xr-x`). If not:
 chmod +x .claude/statusline-command.sh
 ```
 
+---
+
 ### All zeros after multiple prompts
 
-Check that the relevance log file exists:
+**Symptom**: You've submitted several prompts and all metrics remain at zero.
+
+**What's happening**: The statusline script runs fine, but the log file either doesn't exist (hooks never fired) or exists but contains no events for your current session ID.
+
+**Fix**: Check whether the log file exists:
 ```bash
 ls .claude/data/logs/ace-relevance.jsonl
 ```
 
-If the file is missing, ACE hooks have not written any data. Run `/ace-test` to verify hooks are wiring up correctly.
+If it's missing, ACE hooks have not written any data. Run `/ace-test` to verify hooks are wiring up correctly.
 
 If the file exists but metrics stay at zero, inspect the content:
 ```bash
 tail -5 .claude/data/logs/ace-relevance.jsonl | jq '.'
 ```
 
-You should see objects with `event: "search"` and `event: "execution"` entries that have your current `session_id`.
+You should see objects with `event: "search"` and `event: "execution"` entries that have your current `session_id`. If entries exist but with a different session ID, you are looking at data from a previous session — this is normal and the current session will accumulate its own events as you work.
+
+---
 
 ### Statusline shows "ACE: no data"
 
-This means `ace-relevance.jsonl` does not exist in the current project directory. The most common cause is that the ACE hooks have not run yet. Steps to verify:
+**Symptom**: After submitting a prompt, the statusline displays `ACE: no data` rather than metrics.
 
-1. Run `/ace-test` — this will check that hooks are firing.
+**What's happening**: The log file `.claude/data/logs/ace-relevance.jsonl` does not exist in the current project directory. The most common cause is that the ACE hooks have not run yet — either because this is a brand-new project or because the hook configuration is broken.
+
+**Fix**:
+1. Run `/ace-test` — this checks that hooks are firing.
 2. Submit a real prompt and wait for it to complete.
-3. Check that the file was created: `ls .claude/data/logs/ace-relevance.jsonl`.
+3. Confirm the file was created: `ls .claude/data/logs/ace-relevance.jsonl`.
+
+---
 
 ### Slow startup / PLAYBOOK shows "--"
 
-The `--` value on the PLAYBOOK line means the cache is empty and the background fetch is in progress. This is normal on the first statusline render of a session. Wait a few seconds and submit another prompt — the next render will use the populated cache.
+**Symptom**: The PLAYBOOK line shows `--` for the first several seconds of a session.
 
-If the PLAYBOOK line never populates, verify `ace-cli` can reach the server:
+**What's happening**: There is no cache file yet, so the statusline is waiting for the background `ace-cli status` call to complete and populate it. This is normal — it is not an error.
+
+**Fix**: Wait a few seconds and submit another prompt. The next render will use the populated cache. If the PLAYBOOK line never populates after 10–15 seconds, verify `ace-cli` can reach the server:
 ```bash
 ace-cli status --json
 ```
 
 ---
 
-## Next Steps
+## 📚 Next Steps
 
-Once the statusline is running, use it to understand how ACE is performing in your project:
+Once the statusline is running, you can use it as a feedback loop to actively improve ACE's effectiveness in your project:
 
 - **Low QPT / red score** — your playbook may not yet have patterns for the domains you are working in. Run `/ace-bootstrap` to generate initial patterns from your codebase.
-- **Terrain shows "blind spot"** — submit a few tasks and let the Stop hook capture learnings. Playbook coverage grows automatically as you work.
-- **Inj% near zero but Conf% is high** — patterns are being found but not referenced. Check if the patterns are specific enough to your codebase with `/ace-patterns`.
+- **Terrain shows "blind spot"** — submit a few tasks and let the Stop hook capture learnings. Playbook coverage grows automatically as you work; `blind spot` becomes `exploring` becomes `familiar` over time.
+- **Inj% near zero but Conf% is high** — patterns are being found but not referenced. This usually means patterns are too generic. Inspect them with `/ace-patterns` and consider whether they contain specific enough code or commands for your project.
 
 For more on the ACE plugin:
 - [Installation Guide](INSTALL.md)

--- a/plugins/ace/docs/guides/STATUSLINE.md
+++ b/plugins/ace/docs/guides/STATUSLINE.md
@@ -1,0 +1,355 @@
+# ACE Statusline Component Reference
+
+**Version**: v5.4.27
+**Script**: `plugins/ace/scripts/ace-statusline.sh`
+
+---
+
+## Overview
+
+The ACE statusline is a shell script that renders a live session dashboard in Claude Code's status bar. It has two logical sections:
+
+- **ACE section** — session effectiveness metrics sourced from `ace-relevance.jsonl`
+- **CC section** — Claude Code runtime metrics sourced from the input JSON
+
+Output is responsive: the script detects terminal width and selects one of four display modes, from a single score to a full multi-line dashboard.
+
+**Data sources:**
+
+| Source | Latency | Contents |
+|--------|---------|----------|
+| `.claude/data/logs/ace-relevance.jsonl` | <10 ms (local read) | Session events: searches, executions, learning outcomes |
+| `ace-cli status --json` | Network (60 s cached) | Playbook health, usage limits, org/project info |
+| Input JSON (stdin) | Immediate | CC model, context usage, cost, duration, line counts |
+
+---
+
+## Responsive Display Modes
+
+The script detects terminal width using a four-tier fallback (Kitty IPC → `stty` → `tput` → `$COLUMNS`) and maps it to a mode.
+
+| Mode | Min width | Max width | ACE components shown | CC components shown |
+|------|-----------|-----------|----------------------|---------------------|
+| `nano` | 0 | 39 cols | QPT only | Model, context %, cost |
+| `micro` | 40 | 59 cols | QPT, Focus, Conf | Context %, model, cost, time |
+| `mini` | 60 | 99 cols | QPT, Focus, Conf, Inj, playbook health ratio | Context bar (20), %, model, cost, time |
+| `normal` | 100 | — | Full dashboard: all metrics + playbook + usage bar + sparklines | Context bar (40), model, cost, time, CC-Lines |
+
+---
+
+## ACE Section Components
+
+### QPT — Quality Per Task
+
+**What it measures:** A composite score summarising how effective the current session has been at using ACE patterns to deliver value. It aggregates four orthogonal signals into a single 0–100 number.
+
+**Formula:**
+
+```
+QPT = (Focus/100 × 0.35  +
+       Confidence    × 0.30  +
+       LearnRate     × 0.20  +
+       SuccessRate/100 × 0.15) × 100
+```
+
+All inputs are normalised to [0, 1] before weighting. The result is rounded to the nearest integer.
+
+**Weight rationale:**
+
+| Component | Weight | Rationale |
+|-----------|--------|-----------|
+| Focus | 35% | Execution efficiency is the strongest signal of productive work |
+| Confidence | 30% | Pattern quality directly determines how useful injected context is |
+| LearnRate | 20% | Learning propagation is the compounding benefit of ACE |
+| SuccessRate | 15% | Broad success signal; lower weight because it varies by task type |
+
+**Source:** Computed from `SESSION_FOCUS_PCT`, `SESSION_CONFIDENCE`, `SESSION_LEARN_SENT/TOTAL`, and `SESSION_SUCCESS_RATE` aggregated from `ace-relevance.jsonl` for the current session.
+
+**Range and interpretation:**
+
+| Range | Color | Interpretation |
+|-------|-------|----------------|
+| 70–100 | Green | Session is running efficiently with well-matched patterns |
+| 40–69 | Yellow | Partial effectiveness; patterns may be mismatched or execution is exploratory |
+| 0–39 | Red | Low effectiveness; check Conf and Focus for root cause |
+
+A score of 70+ sustained across multiple tasks indicates ACE patterns are well-calibrated for the project domain.
+
+---
+
+### Focus
+
+**What it measures:** The ratio of state-changing tool calls to total tool calls in the session. High focus means Claude is spending its tool budget on writes, edits, and creates rather than reads and explorations.
+
+**Formula:**
+
+```
+Focus = (sum of state_changing_tools across execution events) /
+        (sum of tools_executed across execution events) × 100
+```
+
+**Source:** `execution` events in `ace-relevance.jsonl`, fields `state_changing_tools` and `tools_executed`.
+
+**Range:** 0–100%
+
+**Interpretation:** A high Focus score (≥60%) indicates efficient task execution. A low Focus score suggests the session is heavily exploratory — which may be appropriate early in a task but should rise as implementation proceeds. Persistently low Focus combined with low QPT often signals that injected patterns are not matching the actual work.
+
+---
+
+### Conf — Confidence
+
+**What it measures:** How confident the ACE server is in the patterns it retrieved for the most recent search. This reflects the quality of the playbook entries: patterns that have accumulated many "helpful" votes and few "harmful" votes produce higher confidence scores.
+
+**Formula:**
+
+```
+Conf (%) = avg_confidence from the last search event × 100
+```
+
+The raw `avg_confidence` field on search events is a float in [0.0, 1.0]. The statusline multiplies by 100 and rounds to display as a percentage.
+
+**Source:** `search` events in `ace-relevance.jsonl`, field `avg_confidence`. Only the **last** search event in the session is used, reflecting the most recent retrieval context.
+
+**Range:** 0–100%
+
+**Interpretation:** Higher values mean the patterns returned have strong historical validation from real usage. A low Conf score (below 40%) suggests either the playbook is new and under-voted, the search query did not match well-validated patterns, or the current domain is a blind spot. Use `/ace-search` to inspect what was retrieved.
+
+---
+
+### Inj — Injection Rate
+
+**What it measures:** The fraction of injected patterns that Claude actually referenced during task execution. High injection rate means the patterns were relevant and Claude drew on them.
+
+**Formula:**
+
+```
+Inj (%) = (sum of patterns_used_count across execution events) /
+           (sum of patterns_injected across search events) × 100
+```
+
+**Source:** `ace-relevance.jsonl` — field `patterns_injected` on `search` events, field `patterns_used_count` on `execution` events.
+
+**Range:** 0–100%
+
+**Interpretation:** A high Inj rate (≥70%) indicates retrieved patterns matched the actual task well. A low Inj rate suggests patterns were injected but went unused, which may indicate over-broad retrieval or a mismatch between the query used for retrieval and the work actually performed. Combined with low Conf this can indicate a playbook calibration issue.
+
+---
+
+### Terrain
+
+**What it measures:** The overlap between the domains encountered in the current session and the top five domains in the playbook. It answers: "does ACE have strong coverage for what Claude is doing right now?"
+
+**Computation:**
+
+1. Collect unique domains from all `search` events in the session (`domains[]` array).
+2. Compare against the top five domains by pattern count from `ace-cli domains`.
+3. Compute `overlap_count / session_domain_count × 100`.
+
+**Values:**
+
+| Value | Overlap | Meaning |
+|-------|---------|---------|
+| `familiar` | ≥70% | ACE has strong coverage of current domains |
+| `exploring` | 30–69% | Partial coverage; some domains are new territory |
+| `blind spot` | <30% | ACE has little knowledge of the current domain |
+| `unknown` | no data | No domain data available yet for this session |
+
+**Color:** `familiar` renders green, `exploring` yellow, `blind spot` and `unknown` red.
+
+**Interpretation:** `blind spot` is not necessarily a problem — it means the current work is in an area where the playbook has not yet been trained. Running `/ace-bootstrap` or `/ace-learn` after completing work in that domain will bring it into the familiar range over time.
+
+---
+
+### PLAYBOOK
+
+**What it measures:** A snapshot of the health and size of the project's pattern playbook, fetched from `ace-cli status --json`.
+
+**Fields displayed (normal mode):**
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `N pts` | `playbook.total_patterns` | Total number of patterns in the playbook |
+| Ratio | `helpful_total / (helpful_total + harmful_total) × 100` | Percentage of patterns rated as helpful vs harmful |
+| Domains | `playbook.by_domain \| length` | Number of distinct domains with at least one pattern |
+
+**Caching:** Playbook data is cached in `/tmp/ace-statusline-cache[+project-id].json` for 60 seconds. When the cache is stale the script serves the previous value immediately and refreshes in the background, so the statusline never blocks on a network call.
+
+**Interpretation:** A healthy playbook has a ratio above 80% and covers the domains most active in the project. A ratio below 60% indicates accumulated harmful patterns that should be reviewed with `/ace-patterns`.
+
+---
+
+### USAGE Bar
+
+**What it measures:** Patterns consumed against the plan's pattern limit.
+
+**Computation:**
+
+```
+USAGE_PATTERNS_PCT = USAGE_PATTERNS_USED / USAGE_PATTERNS_LIMIT × 100
+```
+
+The bar is rendered as a row of `⛁` characters. Filled buckets use a continuous color gradient:
+
+| Position | Color |
+|----------|-------|
+| 0–33% | Green |
+| 33–66% | Yellow → Orange |
+| 66–100% | Orange → Red |
+
+Empty bucket positions render in a dark neutral tone.
+
+**Visibility:** The USAGE bar is only rendered when `USAGE_PATTERNS_LIMIT > 0`. Plans without a pattern limit omit the bar entirely.
+
+---
+
+### LEARNING Sparklines
+
+**What it measures:** Event density in `ace-relevance.jsonl` over four time windows, visualised as sparkline bar charts. Each sparkline shows how much ACE activity (searches, executions, learning events) has occurred recently.
+
+**Time windows and bucket parameters:**
+
+| Label | Buckets | Bucket size | Total window |
+|-------|---------|-------------|--------------|
+| 15m | 15 | 60 s | 15 minutes |
+| 60m | 12 | 300 s (5 min) | 60 minutes |
+| 1d | 24 | 3600 s (1 h) | 24 hours |
+| 1w | 7 | 86400 s (1 day) | 7 days |
+
+**Bar heights and colors:**
+
+Each bar is a Unicode block character scaled to event count relative to the window maximum.
+
+| Level (1–10) | Character | Color | Meaning |
+|-------------|-----------|-------|---------|
+| 9–10 | `▅` | Bright green | High activity |
+| 7–8 | `▄` | Green | Moderate-high activity |
+| 5–6 | `▃` | Blue | Moderate activity |
+| 3–4 | `▂` | Yellow | Low activity |
+| 1–2 | `▁` | Light red | Minimal activity |
+| 0 | ` ` | Dark (empty) | No events |
+
+**Interpretation:** Sparklines reveal patterns in ACE usage over time. A dense 15m sparkline with sparse 1w bars indicates a project in active development. A flat 15m sparkline with dense 1d bars may indicate a context that is continuing work from earlier in the day.
+
+**Performance note:** For short windows (bucket size ≤60 s) the script pre-filters to the last 200 lines of the relevance file to avoid parsing the entire log. Longer windows use progressively higher line limits (500, 2000) before falling back to a full scan.
+
+---
+
+## CC Section Components
+
+The CC section surfaces Claude Code runtime metrics from the JSON payload passed to the script on stdin.
+
+### Context Bar
+
+**What it measures:** Percentage of the active context window consumed.
+
+**Source:** `context_window.used_percentage` from the input JSON.
+
+**Color thresholds:**
+
+| Range | Color |
+|-------|-------|
+| <40% | Green |
+| 40–59% | Yellow |
+| 60–79% | Orange |
+| ≥80% | Rose |
+
+In `mini` mode the bar renders at 20 characters wide; in `normal` mode at 40 characters. The same green-to-red gradient used for the USAGE bar applies here.
+
+---
+
+### Model
+
+**What it measures:** The display name of the active Claude model.
+
+**Source:** `model.display_name` from the input JSON.
+
+---
+
+### Cost
+
+**What it measures:** Cumulative API cost for the session in USD.
+
+**Source:** `cost.total_cost_usd` from the input JSON.
+
+**Format:** `$X.XX` (always two decimal places).
+
+---
+
+### Time
+
+**What it measures:** Total wall-clock duration of the session.
+
+**Source:** `cost.total_duration_ms` from the input JSON.
+
+**Format:**
+
+| Duration | Format |
+|----------|--------|
+| <60 s | `Xs` |
+| 60 s – 1 h | `Xm Xs` |
+| ≥1 h | `Xh Xm` |
+
+---
+
+### CC-Lines
+
+**What it measures:** Net code change in the session, expressed as lines added and removed.
+
+**Source:** `cost.total_lines_added` and `cost.total_lines_removed` from the input JSON.
+
+**Format:** `+<added>/-<removed>`
+
+**Visibility:** Only rendered in `normal` mode.
+
+---
+
+## Data File Reference
+
+### ace-relevance.jsonl
+
+Location: `<project-root>/.claude/data/logs/ace-relevance.jsonl`
+
+Each line is a JSON object. The statusline reads two event types:
+
+**`search` event fields used:**
+
+| Field | Type | Used for |
+|-------|------|---------|
+| `session_id` | string | Session filtering |
+| `event` | `"search"` | Event type selector |
+| `avg_confidence` | float [0,1] | Conf metric |
+| `patterns_injected` | int | Inj denominator |
+| `domains[]` | string array | Terrain computation |
+| `timestamp` | ISO 8601 | Sparkline bucketing |
+
+**`execution` event fields used:**
+
+| Field | Type | Used for |
+|-------|------|---------|
+| `session_id` | string | Session filtering |
+| `event` | `"execution"` | Event type selector |
+| `state_changing_tools` | int | Focus numerator |
+| `tools_executed` | int | Focus denominator |
+| `learning_sent` | bool | LearnRate numerator |
+| `success` | bool | SuccessRate numerator |
+| `patterns_used_count` | int | Inj numerator |
+| `timestamp` | ISO 8601 | Sparkline bucketing |
+
+### ace-cli status cache
+
+Location: `/tmp/ace-statusline-cache[+<ACE_PROJECT_ID>].json`
+
+A merged JSON object written by the background refresh process. The cache TTL is 60 seconds. The statusline always reads from the cache and never blocks on a live `ace-cli` call.
+
+---
+
+## Related Documentation
+
+- **Configuration Guide**: [CONFIGURATION.md](./CONFIGURATION.md)
+- **Installation Guide**: [INSTALL.md](./INSTALL.md)
+- **Troubleshooting**: [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
+- **Architecture**: [../technical/ARCHITECTURE.md](../technical/ARCHITECTURE.md)
+
+---
+
+**Questions?** File an issue on the [marketplace repository](https://github.com/ce-dot-net/ce-claude-marketplace/issues).

--- a/plugins/ace/docs/guides/STATUSLINE.md
+++ b/plugins/ace/docs/guides/STATUSLINE.md
@@ -5,6 +5,21 @@
 
 ---
 
+## At a Glance
+
+All metrics, their ranges, color thresholds, and what a reading means — in one place.
+
+| Metric | Range | Green | Yellow | Red | One-line meaning |
+|--------|-------|-------|--------|-----|-----------------|
+| **QPT** | 0–100 | ≥70 | 40–69 | <40 | Overall session effectiveness score |
+| **Focus** | 0–100% | ≥60% | 30–59% | <30% | Tool budget spent on writes vs. reads |
+| **Conf** | 0–100% | ≥70% | 40–69% | <40% | How well-validated the retrieved patterns are |
+| **Inj** | 0–100%+ | ≥70% | 40–69% | <40% | Fraction of injected patterns actually used |
+| **Terrain** | label | `familiar` | `exploring` | `blind spot` / `unknown` | Playbook coverage of current domains |
+| **PLAYBOOK ratio** | 0–100% | ≥80% | 60–79% | <60% | Helpful patterns as a share of all rated patterns |
+
+---
+
 ## Overview
 
 The ACE statusline is a shell script that renders a live session dashboard in Claude Code's status bar. It surfaces ACE session effectiveness metrics sourced from `ace-relevance.jsonl`.
@@ -18,18 +33,34 @@ Output is responsive: the script detects terminal width and selects one of four 
 | `.claude/data/logs/ace-relevance.jsonl` | <10 ms (local read) | Session events: searches, executions, learning outcomes |
 | `ace-cli status --json` | Network (60 s cached) | Playbook health, usage limits, org/project info |
 
+### Data Flow
+
+```
+ace-relevance.jsonl  ──▶  aggregate_session()  ──▶  Focus, Conf, Inj, LearnRate, SuccessRate
+                                                      └──▶  compute_qpt()  ──▶  QPT
+
+ace-cli status --json  ──▶  fetch_playbook_data()  ──▶  PLAYBOOK, USAGE bar
+                             (60s cache)
+
+session_domains + top_domains  ──▶  compute_terrain()  ──▶  Terrain
+```
+
+QPT is a *derived* metric — it rolls up Focus, Conf, LearnRate, and SuccessRate into a single score. The four contributing components are what to inspect when QPT drops.
+
 ---
 
 ## Responsive Display Modes
 
 The script detects terminal width using a four-tier fallback (Kitty IPC → `stty` → `tput` → `$COLUMNS`) and maps it to a mode.
 
-| Mode | Min width | Max width | ACE components shown |
-|------|-----------|-----------|----------------------|
-| `nano` | 0 | 39 cols | QPT only |
-| `micro` | 40 | 59 cols | QPT, Focus, Conf |
-| `mini` | 60 | 99 cols | QPT, Focus, Conf, Inj, playbook health ratio |
-| `normal` | 100 | — | Full dashboard: all metrics + playbook + usage bar + sparklines |
+| Mode | Min width | Max width | Components shown | What disappears vs. previous mode |
+|------|-----------|-----------|------------------|------------------------------------|
+| `nano` | 0 | 39 cols | QPT only | — |
+| `micro` | 40 | 59 cols | QPT, Focus, Conf | — |
+| `mini` | 60 | 99 cols | QPT, Focus, Conf, Inj, playbook health ratio | — |
+| `normal` | 100 | — | Full dashboard: all metrics + playbook + usage bar + sparklines | None — this is the full view |
+
+When your terminal narrows below 100 columns, Inj, Terrain, the USAGE bar, and sparklines are all suppressed. QPT, Focus, and Conf are the last metrics standing at narrow widths because they carry the most diagnostic signal per character.
 
 ---
 
@@ -37,7 +68,9 @@ The script detects terminal width using a four-tier fallback (Kitty IPC → `stt
 
 ### QPT — Quality Per Task
 
-**What it measures:** A composite score summarising how effective the current session has been at using ACE patterns to deliver value. It aggregates four orthogonal signals into a single 0–100 number.
+A single 0–100 composite score. If one number summarises whether the session is going well, this is it.
+
+**What it measures:** QPT aggregates four orthogonal signals — how efficiently Claude is executing, how well-validated the retrieved patterns are, how often learning propagates back to the server, and the overall task success rate. It is a *derived* metric computed from [Focus](#focus--focus), [Conf](#conf--confidence), LearnRate, and SuccessRate.
 
 **Formula:**
 
@@ -71,11 +104,21 @@ All inputs are normalised to [0, 1] before weighting. The result is rounded to t
 
 A score of 70+ sustained across multiple tasks indicates ACE patterns are well-calibrated for the project domain.
 
+**When to act:**
+
+- **QPT < 40**: Check [Conf](#conf--confidence) first — low pattern quality drags QPT most. Then check [Focus](#focus--focus) for exploratory execution. If both are fine, low LearnRate or SuccessRate is the cause.
+- **QPT 40–69 and not rising**: If the session is past initial exploration, this signals a playbook calibration issue. Run `/ace-search` to see what was retrieved; run `/ace-patterns` to review playbook quality.
+- **QPT ≥ 70**: No action needed. A score that stays this high across many sessions means patterns are well-matched to the project.
+
+**Notes:** QPT is 0 before the first `UserPromptSubmit` event fires (no events to aggregate yet). A single-task session with one search and one execution event will produce a meaningful but provisional score — interpret it as directional, not definitive.
+
 ---
 
 ### Focus
 
-**What it measures:** The ratio of state-changing tool calls to total tool calls in the session. High focus means Claude is spending its tool budget on writes, edits, and creates rather than reads and explorations.
+The ratio of work done to exploration. In a well-executing session, this rises as tasks progress.
+
+**What it measures:** The fraction of tool calls in the session that change state (writes, edits, creates) versus the total tool calls fired. High focus means Claude is spending its tool budget on productive work rather than reads and explorations.
 
 **Formula:**
 
@@ -88,13 +131,21 @@ Focus = (sum of state_changing_tools across execution events) /
 
 **Range:** 0–100%
 
-**Interpretation:** A high Focus score (≥60%) indicates efficient task execution. A low Focus score suggests the session is heavily exploratory — which may be appropriate early in a task but should rise as implementation proceeds. Persistently low Focus combined with low QPT often signals that injected patterns are not matching the actual work.
+**When to act:**
+
+- **< 30%**: Session is heavily exploratory. Expected at the start of a task; a concern if it persists through implementation. Check whether injected patterns are actually relevant to the work being done.
+- **30–59%**: Moderate exploration mixed with execution. Normal for tasks involving significant codebase navigation.
+- **≥ 60%**: Efficient task execution. Claude is spending the majority of its tool budget on actual changes.
+
+**Notes:** Focus is only meaningful once execution events exist in the log. It reflects the *cumulative* session ratio — a burst of exploration followed by heavy execution will average out. Monitor the trend over multiple tasks rather than reacting to a single reading.
 
 ---
 
 ### Conf — Confidence
 
-**What it measures:** How confident the ACE server is in the patterns it retrieved for the most recent search. This reflects the quality of the playbook entries: patterns that have accumulated many "helpful" votes and few "harmful" votes produce higher confidence scores.
+A quality signal for the playbook itself. Low Conf means ACE found patterns, but those patterns have not yet earned trust through real-world usage.
+
+**What it measures:** How confident the ACE server is in the patterns it retrieved for the most recent search. Confidence reflects accumulated community signal: patterns that have received many "helpful" votes and few "harmful" votes score higher.
 
 **Formula:**
 
@@ -108,11 +159,19 @@ The raw `avg_confidence` field on search events is a float in [0.0, 1.0]. The st
 
 **Range:** 0–100%
 
-**Interpretation:** Higher values mean the patterns returned have strong historical validation from real usage. A low Conf score (below 40%) suggests either the playbook is new and under-voted, the search query did not match well-validated patterns, or the current domain is a blind spot. Use `/ace-search` to inspect what was retrieved.
+**When to act:**
+
+- **< 40%**: The playbook is either new and under-voted, the search did not match well-validated patterns, or the current domain is a blind spot. Run `/ace-search` to inspect what was retrieved. If the patterns look relevant but unvoted, they will grow in confidence over time as the team uses ACE.
+- **40–69%**: Patterns have some validation. Reasonable for a project in active growth.
+- **≥ 70%**: Patterns have strong historical validation. High Conf combined with low [Inj](#inj--injection-rate) indicates retrieval is working but pattern-task alignment is off.
+
+**Notes:** Conf is always 0 before the first `UserPromptSubmit` of a session — no search event exists yet. Conf and [Inj](#inj--injection-rate) provide complementary signals: Conf measures pattern *quality*, Inj measures pattern *relevance to the actual task*. Both low together is the strongest signal of a calibration problem.
 
 ---
 
 ### Inj — Injection Rate
+
+Measures whether the right patterns were retrieved. High Inj means patterns were not just injected but actually drawn upon.
 
 **What it measures:** The fraction of injected patterns that Claude actually referenced during task execution. High injection rate means the patterns were relevant and Claude drew on them.
 
@@ -125,13 +184,21 @@ Inj (%) = (sum of patterns_used_count across execution events) /
 
 **Source:** `ace-relevance.jsonl` — field `patterns_injected` on `search` events, field `patterns_used_count` on `execution` events.
 
-**Range:** 0–100%
+**Range:** 0–100% (see note below)
 
-**Interpretation:** A high Inj rate (≥70%) indicates retrieved patterns matched the actual task well. A low Inj rate suggests patterns were injected but went unused, which may indicate over-broad retrieval or a mismatch between the query used for retrieval and the work actually performed. Combined with low Conf this can indicate a playbook calibration issue.
+**When to act:**
+
+- **< 40%**: Patterns were injected but went largely unused. Either retrieval is over-broad (query did not match actual work), or the task diverged significantly from the search query. Review what was retrieved with `/ace-search`.
+- **40–69%**: Moderate utilisation. Acceptable, especially for exploratory tasks.
+- **≥ 70%**: Retrieved patterns matched the task well. Combined with high [Conf](#conf--confidence), this is the ideal signal.
+
+**Notes:** Inj can exceed 100% when patterns injected in one search event are reused across multiple subsequent execution events. This is expected behaviour and a positive signal — it means a single retrieval is providing value across multiple tool calls. Inj should be read alongside [Conf](#conf--confidence): Conf measures whether patterns are high-quality, Inj measures whether they were the *right* patterns for the work at hand.
 
 ---
 
 ### Terrain
+
+Tells you whether ACE has useful knowledge for the current work — before you see a low QPT and wonder why.
 
 **What it measures:** The overlap between the domains encountered in the current session and the top five domains in the playbook. It answers: "does ACE have strong coverage for what Claude is doing right now?"
 
@@ -143,20 +210,26 @@ Inj (%) = (sum of patterns_used_count across execution events) /
 
 **Values:**
 
-| Value | Overlap | Meaning |
-|-------|---------|---------|
-| `familiar` | ≥70% | ACE has strong coverage of current domains |
-| `exploring` | 30–69% | Partial coverage; some domains are new territory |
-| `blind spot` | <30% | ACE has little knowledge of the current domain |
-| `unknown` | no data | No domain data available yet for this session |
+| Value | Overlap | Color | Meaning |
+|-------|---------|-------|---------|
+| `familiar` | ≥70% | Green | ACE has strong coverage of current domains |
+| `exploring` | 30–69% | Yellow | Partial coverage; some domains are new territory |
+| `blind spot` | <30% | Red | ACE has little knowledge of the current domain |
+| `unknown` | no data | Red | No domain data available yet for this session |
 
-**Color:** `familiar` renders green, `exploring` yellow, `blind spot` and `unknown` red.
+**When to act:**
 
-**Interpretation:** `blind spot` is not necessarily a problem — it means the current work is in an area where the playbook has not yet been trained. Running `/ace-bootstrap` or `/ace-learn` after completing work in that domain will bring it into the familiar range over time.
+- **`blind spot`**: Not necessarily a problem — it means the playbook has not yet been trained on this domain. Complete the work, then run `/ace-bootstrap` or `/ace-learn` to bring the domain into coverage. Expect [Conf](#conf--confidence) and [Inj](#inj--injection-rate) to be low in the same session.
+- **`exploring`**: Normal for projects expanding into new areas. Coverage will grow naturally as sessions in those domains produce learning events.
+- **`familiar`**: Optimal. Cross-reference with [Conf](#conf--confidence) to confirm that familiar domains also have well-validated patterns.
+
+**Notes:** `unknown` is the initial state of every session before any search event fires. Terrain is complementary to [Conf](#conf--confidence) and [Inj](#inj--injection-rate): Terrain tells you whether the *domain* is covered, Conf tells you whether retrieved *patterns* are high quality, and Inj tells you whether those patterns matched the *specific task*.
 
 ---
 
 ### PLAYBOOK
+
+Playbook health at a glance: how many patterns exist, how trustworthy they are, and how broadly they cover the project.
 
 **What it measures:** A snapshot of the health and size of the project's pattern playbook, fetched from `ace-cli status --json`.
 
@@ -170,7 +243,13 @@ Inj (%) = (sum of patterns_used_count across execution events) /
 
 **Caching:** Playbook data is cached in `/tmp/ace-statusline-cache[+project-id].json` for 60 seconds. When the cache is stale the script serves the previous value immediately and refreshes in the background, so the statusline never blocks on a network call.
 
-**Interpretation:** A healthy playbook has a ratio above 80% and covers the domains most active in the project. A ratio below 60% indicates accumulated harmful patterns that should be reviewed with `/ace-patterns`.
+**When to act:**
+
+- **Ratio < 60%**: Accumulated harmful patterns are degrading retrieval quality. Run `/ace-patterns` to review and prune. Expect [Conf](#conf--confidence) and [QPT](#qpt--quality-per-task) to be suppressed until harmful patterns are removed.
+- **Ratio 60–79%**: Moderate health. Normal for a growing playbook where some early patterns have been marked harmful.
+- **Ratio ≥ 80%**: Healthy playbook. The bulk of patterns are validated as useful.
+
+**Notes:** PLAYBOOK shows `--` on first render if the 60-second cache has not yet been populated. This clears after the first background refresh completes. The display requires `USAGE_PATTERNS_LIMIT > 0` for the USAGE bar (see below) but the health ratio and counts render regardless of plan type.
 
 ---
 
@@ -200,6 +279,8 @@ Empty bucket positions render in a dark neutral tone.
 
 ### LEARNING Sparklines
 
+Activity density over time. Useful for orienting yourself in a long session or confirming that ACE is actively running.
+
 **What it measures:** Event density in `ace-relevance.jsonl` over four time windows, visualised as sparkline bar charts. Each sparkline shows how much ACE activity (searches, executions, learning events) has occurred recently.
 
 **Time windows and bucket parameters:**
@@ -224,7 +305,7 @@ Each bar is a Unicode block character scaled to event count relative to the wind
 | 1–2 | `▁` | Light red | Minimal activity |
 | 0 | ` ` | Dark (empty) | No events |
 
-**Interpretation:** Sparklines reveal patterns in ACE usage over time. A dense 15m sparkline with sparse 1w bars indicates a project in active development. A flat 15m sparkline with dense 1d bars may indicate a context that is continuing work from earlier in the day.
+**Interpretation:** A dense 15m sparkline with sparse 1w bars indicates a project in active development. A flat 15m sparkline with dense 1d bars may indicate a context that is continuing work from earlier in the day.
 
 **Performance note:** For short windows (bucket size ≤60 s) the script pre-filters to the last 200 lines of the relevance file to avoid parsing the entire log. Longer windows use progressively higher line limits (500, 2000) before falling back to a full scan.
 

--- a/plugins/ace/docs/guides/STATUSLINE.md
+++ b/plugins/ace/docs/guides/STATUSLINE.md
@@ -7,10 +7,7 @@
 
 ## Overview
 
-The ACE statusline is a shell script that renders a live session dashboard in Claude Code's status bar. It has two logical sections:
-
-- **ACE section** — session effectiveness metrics sourced from `ace-relevance.jsonl`
-- **CC section** — Claude Code runtime metrics sourced from the input JSON
+The ACE statusline is a shell script that renders a live session dashboard in Claude Code's status bar. It surfaces ACE session effectiveness metrics sourced from `ace-relevance.jsonl`.
 
 Output is responsive: the script detects terminal width and selects one of four display modes, from a single score to a full multi-line dashboard.
 
@@ -20,7 +17,6 @@ Output is responsive: the script detects terminal width and selects one of four 
 |--------|---------|----------|
 | `.claude/data/logs/ace-relevance.jsonl` | <10 ms (local read) | Session events: searches, executions, learning outcomes |
 | `ace-cli status --json` | Network (60 s cached) | Playbook health, usage limits, org/project info |
-| Input JSON (stdin) | Immediate | CC model, context usage, cost, duration, line counts |
 
 ---
 
@@ -28,12 +24,12 @@ Output is responsive: the script detects terminal width and selects one of four 
 
 The script detects terminal width using a four-tier fallback (Kitty IPC → `stty` → `tput` → `$COLUMNS`) and maps it to a mode.
 
-| Mode | Min width | Max width | ACE components shown | CC components shown |
-|------|-----------|-----------|----------------------|---------------------|
-| `nano` | 0 | 39 cols | QPT only | Model, context %, cost |
-| `micro` | 40 | 59 cols | QPT, Focus, Conf | Context %, model, cost, time |
-| `mini` | 60 | 99 cols | QPT, Focus, Conf, Inj, playbook health ratio | Context bar (20), %, model, cost, time |
-| `normal` | 100 | — | Full dashboard: all metrics + playbook + usage bar + sparklines | Context bar (40), model, cost, time, CC-Lines |
+| Mode | Min width | Max width | ACE components shown |
+|------|-----------|-----------|----------------------|
+| `nano` | 0 | 39 cols | QPT only |
+| `micro` | 40 | 59 cols | QPT, Focus, Conf |
+| `mini` | 60 | 99 cols | QPT, Focus, Conf, Inj, playbook health ratio |
+| `normal` | 100 | — | Full dashboard: all metrics + playbook + usage bar + sparklines |
 
 ---
 
@@ -231,75 +227,6 @@ Each bar is a Unicode block character scaled to event count relative to the wind
 **Interpretation:** Sparklines reveal patterns in ACE usage over time. A dense 15m sparkline with sparse 1w bars indicates a project in active development. A flat 15m sparkline with dense 1d bars may indicate a context that is continuing work from earlier in the day.
 
 **Performance note:** For short windows (bucket size ≤60 s) the script pre-filters to the last 200 lines of the relevance file to avoid parsing the entire log. Longer windows use progressively higher line limits (500, 2000) before falling back to a full scan.
-
----
-
-## CC Section Components
-
-The CC section surfaces Claude Code runtime metrics from the JSON payload passed to the script on stdin.
-
-### Context Bar
-
-**What it measures:** Percentage of the active context window consumed.
-
-**Source:** `context_window.used_percentage` from the input JSON.
-
-**Color thresholds:**
-
-| Range | Color |
-|-------|-------|
-| <40% | Green |
-| 40–59% | Yellow |
-| 60–79% | Orange |
-| ≥80% | Rose |
-
-In `mini` mode the bar renders at 20 characters wide; in `normal` mode at 40 characters. The same green-to-red gradient used for the USAGE bar applies here.
-
----
-
-### Model
-
-**What it measures:** The display name of the active Claude model.
-
-**Source:** `model.display_name` from the input JSON.
-
----
-
-### Cost
-
-**What it measures:** Cumulative API cost for the session in USD.
-
-**Source:** `cost.total_cost_usd` from the input JSON.
-
-**Format:** `$X.XX` (always two decimal places).
-
----
-
-### Time
-
-**What it measures:** Total wall-clock duration of the session.
-
-**Source:** `cost.total_duration_ms` from the input JSON.
-
-**Format:**
-
-| Duration | Format |
-|----------|--------|
-| <60 s | `Xs` |
-| 60 s – 1 h | `Xm Xs` |
-| ≥1 h | `Xh Xm` |
-
----
-
-### CC-Lines
-
-**What it measures:** Net code change in the session, expressed as lines added and removed.
-
-**Source:** `cost.total_lines_added` and `cost.total_lines_removed` from the input JSON.
-
-**Format:** `+<added>/-<removed>`
-
-**Visibility:** Only rendered in `normal` mode.
 
 ---
 

--- a/plugins/ace/scripts/ace-statusline.sh
+++ b/plugins/ace/scripts/ace-statusline.sh
@@ -1,0 +1,816 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# ACE Status Line — working-buddy
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Visualizes ACE (Agentic Context Engineering) session effectiveness metrics
+# in Claude Code's status bar.
+#
+# Responsive display modes based on terminal width:
+#   - nano   (<40 cols):  QPT only
+#   - micro  (40-59):     QPT + focus + confidence
+#   - mini   (60-99):     QPT + metrics + playbook health
+#   - normal (100+):      Full dashboard with sparkline activity charts
+#
+# Data sources:
+#   - ace-relevance.jsonl (local, <10ms) — session metrics + sparklines
+#   - ace-cli status --json (60s cache) — playbook health
+#
+# Dependencies: jq, date, ace-cli (optional)
+# ═══════════════════════════════════════════════════════════════════════════════
+set -o pipefail
+
+# Allow sourcing for tests without executing main
+if [ "${1:-}" = "--source-only" ]; then
+  _SOURCE_ONLY=true
+fi
+
+# ─── CONFIGURATION ───────────────────────────────────────────────────────────
+
+ACE_RELEVANCE=".claude/data/logs/ace-relevance.jsonl"
+ACE_CACHE="/tmp/ace-statusline-cache${ACE_PROJECT_ID:+-$ACE_PROJECT_ID}.json"
+ACE_CACHE_TTL=60
+
+# ─── COLOR PALETTE (ACE brand: #2CF1BE primary, #212126 dark) ────────────────
+
+RESET='\033[0m'
+DIM='\033[2;37m'
+BOLD='\033[1;37m'
+# ACE brand teal #2CF1BE
+ACE_PRIMARY='\033[38;2;44;241;190m'
+ACE_PRIMARY_DIM='\033[38;2;30;170;134m'
+# Status colors
+GREEN='\033[38;2;74;222;128m'
+YELLOW='\033[38;2;250;204;21m'
+RED='\033[38;2;239;68;68m'
+CYAN='\033[38;2;44;241;190m'
+BOLD_CYAN='\033[1;38;2;44;241;190m'
+
+# ─── COLOR HELPERS ──────────────────────────────────────────────────────────
+
+qpt_color() {
+  local score="$1"
+  if [ "$score" -ge 70 ]; then
+    printf '%s' "$GREEN"
+  elif [ "$score" -ge 40 ]; then
+    printf '%s' "$YELLOW"
+  else
+    printf '%s' "$RED"
+  fi
+}
+
+terrain_color() {
+  case "$1" in
+    familiar) printf '%s' "$GREEN" ;;
+    exploring) printf '%s' "$YELLOW" ;;
+    *) printf '%s' "$RED" ;;
+  esac
+}
+
+# ─── USAGE BAR (PAI-style ⛁ with green→yellow→orange→red gradient) ─────────
+
+# Color gradient for usage bar position: green→yellow→orange→red
+get_usage_bucket_color() {
+  local pos=$1 max=$2
+  local pct=$((pos * 100 / max))
+  local r g b
+  if [ "$pct" -le 33 ]; then
+    r=$((74 + (250 - 74) * pct / 33))
+    g=$((222 + (204 - 222) * pct / 33))
+    b=$((128 + (21 - 128) * pct / 33))
+  elif [ "$pct" -le 66 ]; then
+    local t=$((pct - 33))
+    r=$((250 + (251 - 250) * t / 33))
+    g=$((204 + (146 - 204) * t / 33))
+    b=$((21 + (60 - 21) * t / 33))
+  else
+    local t=$((pct - 66))
+    r=$((251 + (239 - 251) * t / 34))
+    g=$((146 + (68 - 146) * t / 34))
+    b=$((60 + (68 - 60) * t / 34))
+  fi
+  printf '\033[38;2;%d;%d;%dm' "$r" "$g" "$b"
+}
+
+USAGE_BUCKET_EMPTY='\033[38;2;45;50;60m'
+
+render_usage_bar() {
+  local width=$1 pct=$2
+  local output=""
+  [ "$pct" -gt 100 ] && pct=100
+  local filled=$((pct * width / 100))
+  [ "$filled" -lt 0 ] && filled=0
+  local i
+  for ((i = 1; i <= width; i++)); do
+    if [ "$i" -le "$filled" ]; then
+      local color
+      color=$(get_usage_bucket_color "$i" "$width")
+      output="${output}${color}⛁${RESET}"
+    else
+      output="${output}${USAGE_BUCKET_EMPTY}⛁${RESET}"
+    fi
+  done
+  echo -e "$output"
+}
+
+# ─── CROSS-PLATFORM HELPERS ─────────────────────────────────────────────────
+
+# get_mtime(filepath) — file modification time in seconds since epoch
+get_mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+# ─── SESSION AGGREGATION ────────────────────────────────────────────────────
+
+# aggregate_session(session_id, relevance_file)
+# Reads ace-relevance.jsonl and sets global variables for the given session.
+# Uses a single jq -rs invocation to compute all metrics at once.
+aggregate_session() {
+  local sid="$1"
+  local rfile="$2"
+
+  # Defaults — used when file missing, session absent, or jq fails
+  SESSION_FOCUS_PCT=0
+  SESSION_CONFIDENCE="0"
+  SESSION_LEARN_SENT=0
+  SESSION_LEARN_TOTAL=0
+  SESSION_SUCCESS_RATE=0
+  SESSION_DOMAINS=""
+  SESSION_INJ_TOTAL=0
+  SESSION_INJ_USED=0
+
+  if [ ! -f "$rfile" ]; then
+    return 0
+  fi
+
+  eval "$(jq -rs --arg sid "$sid" '
+    [ .[] | select(.session_id == $sid) ] as $events |
+    if ($events | length) == 0 then
+      "SESSION_FOCUS_PCT=0\nSESSION_CONFIDENCE='\''0'\''\nSESSION_LEARN_SENT=0\nSESSION_LEARN_TOTAL=0\nSESSION_SUCCESS_RATE=0\nSESSION_DOMAINS='\'\''\nSESSION_INJ_TOTAL=0\nSESSION_INJ_USED=0"
+    else
+      # Execution events
+      [ $events[] | select(.event == "execution") ] as $execs |
+      # Search events
+      [ $events[] | select(.event == "search") ] as $searches |
+
+      # Focus: state_changing / tools_executed * 100
+      (if ($execs | length) > 0 then
+        ([ $execs[].state_changing_tools ] | add) as $sc |
+        ([ $execs[].tools_executed ] | add) as $te |
+        if $te > 0 then (($sc * 100) / $te | floor) else 0 end
+      else 0 end) as $focus |
+
+      # Confidence: avg_confidence from the LAST search event (by array order)
+      (if ($searches | length) > 0 then
+        ($searches | last | .avg_confidence | tostring)
+      else "0" end) as $conf |
+
+      # Learning sent / total
+      (if ($execs | length) > 0 then
+        [ $execs[] | select(.learning_sent == true) ] | length
+      else 0 end) as $lsent |
+      ($execs | length) as $ltotal |
+
+      # Success rate
+      (if ($execs | length) > 0 then
+        (([ $execs[] | select(.success == true) ] | length) * 100 / ($execs | length) | floor)
+      else 0 end) as $srate |
+
+      # Unique domains
+      ([ $searches[].domains[]? ] | unique | join(",")) as $doms |
+
+      # Injection: patterns_injected (search) and patterns_used_count (exec)
+      ([ $searches[].patterns_injected // 0 ] | add // 0) as $inj_total |
+      ([ $execs[].patterns_used_count // 0 ] | add // 0) as $inj_used |
+
+      "SESSION_FOCUS_PCT=\($focus)\nSESSION_CONFIDENCE=\($conf | @sh)\nSESSION_LEARN_SENT=\($lsent)\nSESSION_LEARN_TOTAL=\($ltotal)\nSESSION_SUCCESS_RATE=\($srate)\nSESSION_DOMAINS=\($doms | @sh)\nSESSION_INJ_TOTAL=\($inj_total)\nSESSION_INJ_USED=\($inj_used)"
+    end
+  ' "$rfile" 2>/dev/null)" || {
+    SESSION_FOCUS_PCT=0
+    SESSION_CONFIDENCE="0"
+    SESSION_LEARN_SENT=0
+    SESSION_LEARN_TOTAL=0
+    SESSION_SUCCESS_RATE=0
+    SESSION_DOMAINS=""
+    SESSION_INJ_TOTAL=0
+    SESSION_INJ_USED=0
+  }
+}
+
+# ─── PLAYBOOK DATA (ACE-CLI CACHE) ─────────────────────────────────────────
+
+# fetch_playbook_data()
+# Reads ace-cli data from cache, refreshes in background when stale.
+# Sets: PLAYBOOK_PATTERNS, PLAYBOOK_HEALTHY_PCT, PLAYBOOK_DOMAINS, PLAYBOOK_TOP_DOMAINS,
+#        ACE_ORG_NAME, ACE_PROJECT_NAME
+fetch_playbook_data() {
+  # Defaults
+  PLAYBOOK_PATTERNS="--"
+  PLAYBOOK_HEALTHY_PCT=0
+  PLAYBOOK_DOMAINS=0
+  PLAYBOOK_TOP_DOMAINS=""
+  ACE_ORG_NAME=""
+  ACE_PROJECT_NAME=""
+  USAGE_PATTERNS_USED=0
+  USAGE_PATTERNS_LIMIT=0
+  USAGE_PATTERNS_PCT=0
+  USAGE_TRACES_USED=0
+  USAGE_TRACES_LIMIT=0
+  USAGE_API_USED=0
+  USAGE_API_LIMIT=0
+
+  local now
+  now=$(date +%s)
+
+  _parse_playbook_cache() {
+    local cache_file="$1"
+    local total
+    total=$(jq -r '.playbook.total_patterns // 0' "$cache_file" 2>/dev/null)
+    PLAYBOOK_PATTERNS="${total:-0}"
+
+    local helpful
+    helpful=$(jq -r '.playbook.helpful_total // 0' "$cache_file" 2>/dev/null)
+    helpful=${helpful%%.*}  # truncate float to integer for bash arithmetic
+    local harmful
+    harmful=$(jq -r '.playbook.harmful_total // 0' "$cache_file" 2>/dev/null)
+    harmful=${harmful%%.*}  # truncate float to integer for bash arithmetic
+    local denom=$((helpful + harmful))
+    if [ "$denom" -gt 0 ]; then
+      PLAYBOOK_HEALTHY_PCT=$((helpful * 100 / denom))
+    else
+      PLAYBOOK_HEALTHY_PCT=0
+    fi
+
+    local dom_count
+    dom_count=$(jq -r '.playbook.by_domain | length // 0' "$cache_file" 2>/dev/null)
+    PLAYBOOK_DOMAINS="${dom_count:-0}"
+
+    local top
+    top=$(jq -r '.top_domains // ""' "$cache_file" 2>/dev/null)
+    PLAYBOOK_TOP_DOMAINS="${top:-}"
+
+    local oname
+    oname=$(jq -r '.ace_org_name // ""' "$cache_file" 2>/dev/null)
+    ACE_ORG_NAME="${oname:-}"
+    local pname
+    pname=$(jq -r '.ace_project_name // ""' "$cache_file" 2>/dev/null)
+    ACE_PROJECT_NAME="${pname:-}"
+
+    # Usage / consumption limits
+    local pat_used pat_limit traces_used traces_limit api_used api_limit
+    pat_used=$(jq -r '.subscription.usage.patterns.used // 0' "$cache_file" 2>/dev/null)
+    pat_limit=$(jq -r '.subscription.usage.patterns.limit // 0' "$cache_file" 2>/dev/null)
+    traces_used=$(jq -r '.subscription.usage.traces_today.used // 0' "$cache_file" 2>/dev/null)
+    traces_limit=$(jq -r '.subscription.usage.traces_today.limit // 0' "$cache_file" 2>/dev/null)
+    api_used=$(jq -r '.subscription.usage.api_calls.used // 0' "$cache_file" 2>/dev/null)
+    api_limit=$(jq -r '.subscription.usage.api_calls.limit // 0' "$cache_file" 2>/dev/null)
+    USAGE_PATTERNS_USED="${pat_used:-0}"
+    USAGE_PATTERNS_LIMIT="${pat_limit:-0}"
+    USAGE_TRACES_USED="${traces_used:-0}"
+    USAGE_TRACES_LIMIT="${traces_limit:-0}"
+    USAGE_API_USED="${api_used:-0}"
+    USAGE_API_LIMIT="${api_limit:-0}"
+    if [ "${USAGE_PATTERNS_LIMIT:-0}" -gt 0 ] 2>/dev/null; then
+      USAGE_PATTERNS_PCT=$((USAGE_PATTERNS_USED * 100 / USAGE_PATTERNS_LIMIT))
+    else
+      USAGE_PATTERNS_PCT=0
+    fi
+  }
+
+  _bg_refresh_cache() {
+    local cache_file="$1"
+    (
+      local status_json
+      status_json=$(ace-cli status --json 2>/dev/null) || return
+      local domains_json
+      domains_json=$(ace-cli domains --json 2>/dev/null) || return
+
+      local top5
+      top5=$(echo "$domains_json" | jq -r '[.domains[:5][].name] | join(",")' 2>/dev/null)
+
+      # Resolve org name from whoami
+      local org_name=""
+      local whoami_json
+      if whoami_json=$(ace-cli whoami --json 2>/dev/null); then
+        local cur_org
+        cur_org=$(echo "$whoami_json" | jq -r '.current_org_id // ""' 2>/dev/null)
+        if [ -n "$cur_org" ]; then
+          org_name=$(echo "$whoami_json" | jq -r --arg oid "$cur_org" \
+            '.user.organizations[] | select(.org_id == $oid) | .name // ""' 2>/dev/null)
+        fi
+      fi
+
+      # Resolve project name from projects list
+      local proj_name=""
+      local proj_id="${ACE_PROJECT_ID:-}"
+      if [ -n "$proj_id" ]; then
+        local projects_json
+        if projects_json=$(ace-cli projects --json 2>/dev/null); then
+          proj_name=$(echo "$projects_json" | jq -r --arg pid "$proj_id" \
+            '.projects[] | select(.project_id == $pid) | .project_name // ""' 2>/dev/null)
+        fi
+      fi
+
+      echo "$status_json" | jq \
+        --arg td "$top5" \
+        --arg on "$org_name" \
+        --arg pn "$proj_name" \
+        '. + {top_domains: $td, ace_org_name: $on, ace_project_name: $pn}' \
+        >"${cache_file}.tmp" 2>/dev/null &&
+        mv "${cache_file}.tmp" "$cache_file"
+    ) &
+    disown
+  }
+
+  if [ -f "$ACE_CACHE" ]; then
+    local mtime
+    mtime=$(get_mtime "$ACE_CACHE")
+    local age=$((now - mtime))
+
+    _parse_playbook_cache "$ACE_CACHE"
+
+    if [ "$age" -ge "${ACE_CACHE_TTL:-60}" ]; then
+      # Stale — refresh in background
+      _bg_refresh_cache "$ACE_CACHE"
+    fi
+  else
+    # No cache at all — keep defaults, refresh in background
+    _bg_refresh_cache "$ACE_CACHE"
+  fi
+}
+
+# ─── ACE QPT (QUALITY PER TASK) ─────────────────────────────────────────────
+
+compute_qpt() {
+  local learn_rate=0
+  if [ "${SESSION_LEARN_TOTAL:-0}" -gt 0 ]; then
+    learn_rate=$(jq -n "${SESSION_LEARN_SENT} / ${SESSION_LEARN_TOTAL}")
+  fi
+
+  ACE_QPT=$(jq -n "
+    (${SESSION_FOCUS_PCT:-0} / 100 * 0.35 +
+     ${SESSION_CONFIDENCE:-0} * 0.30 +
+     $learn_rate * 0.20 +
+     ${SESSION_SUCCESS_RATE:-0} / 100 * 0.15) * 100 | round
+  ")
+  ACE_QPT="${ACE_QPT:-0}"
+}
+
+# ─── TERRAIN INDICATOR ─────────────────────────────────────────────────────
+
+compute_terrain() {
+  local session_domains="${SESSION_DOMAINS:-}"
+  local top_domains="${PLAYBOOK_TOP_DOMAINS:-}"
+
+  if [ -z "$session_domains" ] || [ -z "$top_domains" ]; then
+    ACE_TERRAIN="unknown"
+    return
+  fi
+
+  local overlap=0 session_count=0
+  local IFS=','
+  for domain in $session_domains; do
+    session_count=$((session_count + 1))
+    case ",$top_domains," in
+      *,"$domain",*) overlap=$((overlap + 1)) ;;
+    esac
+  done
+
+  if [ "$session_count" -eq 0 ]; then
+    ACE_TERRAIN="unknown"
+  elif [ $((overlap * 100 / session_count)) -ge 70 ]; then
+    ACE_TERRAIN="familiar"
+  elif [ $((overlap * 100 / session_count)) -ge 30 ]; then
+    ACE_TERRAIN="exploring"
+  else
+    ACE_TERRAIN="blind spot"
+  fi
+}
+
+# ─── SPARKLINE RENDERING ─────────────────────────────────────────────────────
+
+render_sparkline() {
+  local buckets_str="$1"
+  local -a buckets
+  read -ra buckets <<<"$buckets_str"
+
+  local max=0
+  for val in "${buckets[@]}"; do
+    [ "$val" -gt "$max" ] && max="$val"
+  done
+
+  if [ "$max" -eq 0 ]; then
+    local out=""
+    for _ in "${buckets[@]}"; do out="${out} "; done
+    echo "$out"
+    return
+  fi
+
+  # PAI-style: block height encodes value level, color encodes quality band
+  # 10 levels mapped to 5 block heights with distinct colors
+  # High activity = tall green, low activity = short red
+  local out=""
+  for val in "${buckets[@]}"; do
+    if [ "$val" -eq 0 ]; then
+      out="${out}\033[38;2;45;50;60m \033[0m"
+    else
+      local level=$(((val * 10 + max - 1) / max))
+      [ "$level" -gt 10 ] && level=10
+      [ "$level" -lt 1 ] && level=1
+      if [ "$level" -ge 9 ]; then
+        out="${out}\033[38;2;34;197;94m▅\033[0m"     # bright green
+      elif [ "$level" -ge 7 ]; then
+        out="${out}\033[38;2;74;222;128m▄\033[0m"    # green
+      elif [ "$level" -ge 5 ]; then
+        out="${out}\033[38;2;59;130;246m▃\033[0m"    # blue
+      elif [ "$level" -ge 3 ]; then
+        out="${out}\033[38;2;253;224;71m▂\033[0m"    # yellow
+      else
+        out="${out}\033[38;2;248;113;113m▁\033[0m"   # light red
+      fi
+    fi
+  done
+  echo -e "$out"
+}
+
+# ─── TIME-BUCKETED EVENT COUNTING ───────────────────────────────────────────
+
+bucket_events() {
+  local relevance_file="$1"
+  local num_buckets="$2"
+  local bucket_seconds="$3"
+
+  local now
+  now=$(date +%s)
+  local window_start=$((now - num_buckets * bucket_seconds))
+
+  # Pre-filter: for short windows, only read recent lines to avoid parsing entire file
+  local max_lines=0
+  if [ "$bucket_seconds" -le 60 ]; then
+    max_lines=200
+  elif [ "$bucket_seconds" -le 300 ]; then
+    max_lines=500
+  elif [ "$bucket_seconds" -le 3600 ]; then
+    max_lines=2000
+  fi
+
+  local input_file="$relevance_file"
+  local tmp_file=""
+  if [ "$max_lines" -gt 0 ]; then
+    tmp_file="/tmp/ace-bucket-$$"
+    tail -n "$max_lines" "$relevance_file" >"$tmp_file" 2>/dev/null
+    input_file="$tmp_file"
+  fi
+
+  local result
+  if result=$(jq -rs --argjson start "$window_start" \
+    --argjson bsec "$bucket_seconds" \
+    --argjson nbuckets "$num_buckets" '
+    [.[] | select(type == "object" and has("timestamp")) | .timestamp |
+      (sub("[.+Z].*$"; "") + "Z" | fromdateiso8601) as $ts |
+      select($ts >= $start) |
+      (($ts - $start) / $bsec | floor)
+    ] as $indices |
+    [range($nbuckets)] | map(. as $i | [$indices[] | select(. == $i)] | length) |
+    map(tostring) | join(" ")
+  ' "$input_file" 2>/dev/null); then
+    [ -n "$tmp_file" ] && rm -f "$tmp_file"
+    echo "$result"
+  else
+    [ -n "$tmp_file" ] && rm -f "$tmp_file"
+    # Fallback: return all zeros
+    local zeros=""
+    for ((i = 0; i < num_buckets; i++)); do
+      zeros="${zeros}0 "
+    done
+    echo "${zeros% }"
+  fi
+}
+
+# ─── CC (CLAUDE CODE) STATUS LINE ──────────────────────────────────────────
+
+# Colors for CC section
+CC_PRIMARY='\033[38;2;129;140;248m'     # Indigo
+CC_SECONDARY='\033[38;2;165;180;252m'   # Light indigo
+CC_BUCKET_EMPTY='\033[38;2;75;82;95m'
+
+get_cc_bucket_color() {
+  local pos=$1 max=$2
+  local pct=$((pos * 100 / max))
+  local r g b
+  if [ "$pct" -le 33 ]; then
+    r=$((74 + (250 - 74) * pct / 33))
+    g=$((222 + (204 - 222) * pct / 33))
+    b=$((128 + (21 - 128) * pct / 33))
+  elif [ "$pct" -le 66 ]; then
+    local t=$((pct - 33))
+    r=$((250 + (251 - 250) * t / 33))
+    g=$((204 + (146 - 204) * t / 33))
+    b=$((21 + (60 - 21) * t / 33))
+  else
+    local t=$((pct - 66))
+    r=$((251 + (239 - 251) * t / 34))
+    g=$((146 + (68 - 146) * t / 34))
+    b=$((60 + (68 - 60) * t / 34))
+  fi
+  printf '\033[38;2;%d;%d;%dm' "$r" "$g" "$b"
+}
+
+render_cc_context_bar() {
+  local width=$1 pct=$2
+  local output=""
+  [ "$pct" -gt 100 ] && pct=100
+  local filled=$((pct * width / 100))
+  [ "$filled" -lt 0 ] && filled=0
+  local i
+  for ((i = 1; i <= width; i++)); do
+    if [ "$i" -le "$filled" ]; then
+      local color
+      color=$(get_cc_bucket_color "$i" "$width")
+      output="${output}${color}⛁${RESET}"
+    else
+      output="${output}${CC_BUCKET_EMPTY}⛁${RESET}"
+    fi
+  done
+  echo -e "$output"
+}
+
+render_cc_status() {
+  local pct="${cc_context_pct:-0}"
+  pct="${pct%%.*}"
+  [ -z "$pct" ] && pct=0
+
+  # Context color
+  local pct_color
+  if [ "$pct" -ge 80 ]; then
+    pct_color='\033[38;2;251;113;133m'   # Rose
+  elif [ "$pct" -ge 60 ]; then
+    pct_color='\033[38;2;251;146;60m'    # Orange
+  elif [ "$pct" -ge 40 ]; then
+    pct_color='\033[38;2;251;191;36m'    # Yellow
+  else
+    pct_color="${GREEN}"                  # Green
+  fi
+
+  # Format duration
+  local dur_sec=$(( ${cc_duration_ms:-0} / 1000 ))
+  local time_display
+  if [ "$dur_sec" -ge 3600 ]; then
+    time_display="$((dur_sec / 3600))h$((dur_sec % 3600 / 60))m"
+  elif [ "$dur_sec" -ge 60 ]; then
+    time_display="$((dur_sec / 60))m$((dur_sec % 60))s"
+  else
+    time_display="${dur_sec}s"
+  fi
+
+  # Format cost
+  local cost_display
+  cost_display=$(printf '$%.2f' "${cc_cost:-0}")
+
+  case "$MODE" in
+    nano)
+      printf "${DIM}${cc_model:-?}${RESET} ${pct_color}${pct}%%${RESET} ${DIM}${cost_display}${RESET}\n"
+      ;;
+    micro)
+      printf "${CC_PRIMARY}◉${RESET} ${pct_color}${pct}%%${RESET}"
+      printf " ${DIM}${cc_model:-?}${RESET}"
+      printf " ${DIM}${cost_display}${RESET}"
+      printf " ${DIM}${time_display}${RESET}\n"
+      ;;
+    mini)
+      local bar
+      bar=$(render_cc_context_bar 20 "$pct")
+      printf "${CC_PRIMARY}◉${RESET} ${CC_SECONDARY}CTX:${RESET} ${bar} ${pct_color}${pct}%%${RESET}"
+      printf "  ${DIM}${cc_model:-?}${RESET}"
+      printf "  ${DIM}${cost_display}${RESET}"
+      printf "  ${DIM}${time_display}${RESET}\n"
+      ;;
+    normal)
+      local bar
+      bar=$(render_cc_context_bar 40 "$pct")
+      printf "${CC_PRIMARY}◉${RESET} ${CC_SECONDARY}CTX:${RESET} ${bar} ${pct_color}${pct}%%${RESET}\n"
+      printf "${CC_PRIMARY}▸${RESET} ${DIM}Model:${RESET} ${BOLD}${cc_model:-?}${RESET}"
+      printf "  ${DIM}Cost:${RESET} ${cost_display}"
+      printf "  ${DIM}Time:${RESET} ${time_display}"
+      printf "  ${DIM}CC-Lines:${RESET} +${cc_lines_added:-0}/-${cc_lines_removed:-0}"
+      [ -n "${cc_version}" ] && printf "  ${DIM}CC:${RESET} ${cc_version}"
+      printf "\n"
+      ;;
+  esac
+}
+
+# ─── RENDER OUTPUT ──────────────────────────────────────────────────────────
+
+render_output() {
+  # ── CC status first ──
+  render_cc_status
+
+  local sc
+  sc=$(qpt_color "${ACE_QPT:-0}")
+
+  case "$MODE" in
+    nano)
+      printf "${ACE_PRIMARY_DIM}ACE:${RESET}${sc}${ACE_QPT:-0}${RESET}\n"
+      ;;
+    micro)
+      printf "${ACE_PRIMARY_DIM}ACE:${RESET}${sc}${ACE_QPT:-0}${RESET}"
+      printf " ${DIM}F:${RESET}${SESSION_FOCUS_PCT:-0}%%"
+      printf " ${DIM}C:${RESET}${SESSION_CONFIDENCE_PCT:-0}%%\n"
+      ;;
+    mini)
+      printf "${ACE_PRIMARY}◉${RESET} ${sc}${ACE_QPT:-0}${RESET}"
+      printf "  ${DIM}F:${RESET}${SESSION_FOCUS_PCT:-0}%%"
+      printf "  ${DIM}C:${RESET}${SESSION_CONFIDENCE_PCT:-0}%%"
+      printf "  ${DIM}I:${RESET}${SESSION_INJ_PCT:-0}%%"
+      printf "  ${ACE_PRIMARY}♦${RESET} ${PLAYBOOK_HEALTHY_PCT:-0}%%\n"
+      ;;
+    normal)
+      local tc
+      tc=$(terrain_color "${ACE_TERRAIN:-unknown}")
+      local project_upper
+      project_upper=$(echo "${ACE_PROJECT_NAME:-${dir_name:-project}}" | tr '[:lower:]' '[:upper:]')
+      local org_display="${ACE_ORG_NAME:-}"
+
+      # Header: org dimmed ▸ PROJECT bold
+      if [ -n "$org_display" ]; then
+        printf "${ACE_PRIMARY_DIM}── │${RESET} ${ACE_PRIMARY}ACE STATUSLINE${RESET} ${ACE_PRIMARY_DIM}│ ────${RESET} ${DIM}${org_display}${RESET} ${ACE_PRIMARY_DIM}▸${RESET} ${BOLD_CYAN}${project_upper}${RESET}\n"
+      else
+        printf "${ACE_PRIMARY_DIM}── │${RESET} ${ACE_PRIMARY}ACE STATUSLINE${RESET} ${ACE_PRIMARY_DIM}│ ────────────────────────${RESET} ${BOLD_CYAN}${project_upper}${RESET}\n"
+      fi
+      # Score line
+      printf "${ACE_PRIMARY}◉ QPT:${RESET} ${sc}${ACE_QPT:-0}${RESET}"
+      printf "  ${DIM}Focus:${RESET} ${SESSION_FOCUS_PCT:-0}%%"
+      printf "  ${DIM}Conf:${RESET} ${SESSION_CONFIDENCE_PCT:-0}%%"
+      printf "  ${DIM}Inj:${RESET} ${SESSION_INJ_PCT:-0}%%"
+      printf "  ${DIM}Terrain:${RESET} ${tc}${ACE_TERRAIN:-unknown}${RESET}\n"
+      # Separator
+      printf "${ACE_PRIMARY_DIM}────────────────────────────────────────────────────────────────────${RESET}\n"
+      # Playbook line
+      printf "${ACE_PRIMARY}♦ PLAYBOOK:${RESET} ${PLAYBOOK_PATTERNS:-0} pts"
+      printf "  ${DIM}Ratio:${RESET} ${PLAYBOOK_HEALTHY_PCT:-0}%% healthy"
+      printf "  ${DIM}Domains:${RESET} ${PLAYBOOK_DOMAINS:-0}\n"
+      # Usage bar (patterns consumption)
+      if [ "${USAGE_PATTERNS_LIMIT:-0}" -gt 0 ] 2>/dev/null; then
+        local usage_bar
+        usage_bar=$(render_usage_bar 30 "${USAGE_PATTERNS_PCT:-0}")
+        printf "${ACE_PRIMARY}▪ USAGE:${RESET}    ${usage_bar} ${DIM}${USAGE_PATTERNS_PCT:-0}%%${RESET}"
+        printf " ${DIM}(${USAGE_PATTERNS_USED:-0}/${USAGE_PATTERNS_LIMIT:-0})${RESET}\n"
+      fi
+      # Separator
+      printf "${ACE_PRIMARY_DIM}────────────────────────────────────────────────────────────────────${RESET}\n"
+      # Sparkline header — show '-' instead of 0
+      local c15m="${SPARK_COUNT_15M:-0}" c1h="${SPARK_COUNT_1H:-0}" c1d="${SPARK_COUNT_1D:-0}" c1w="${SPARK_COUNT_1W:-0}"
+      [ "$c15m" -eq 0 ] 2>/dev/null && c15m="-"
+      [ "$c1h" -eq 0 ] 2>/dev/null && c1h="-"
+      [ "$c1d" -eq 0 ] 2>/dev/null && c1d="-"
+      [ "$c1w" -eq 0 ] 2>/dev/null && c1w="-"
+      printf "${ACE_PRIMARY}✿ LEARNING:${RESET}"
+      printf "  ${DIM}15m:${RESET} ${c15m}"
+      printf " ${DIM}│${RESET} ${DIM}60m:${RESET} ${c1h}"
+      printf " ${DIM}│${RESET} ${DIM}1d:${RESET} ${c1d}"
+      printf " ${DIM}│${RESET} ${DIM}1w:${RESET} ${c1w}\n"
+      # Sparkline rows — tree-style prefixes, aligned labels
+      printf "${ACE_PRIMARY_DIM}├─ 15m:${RESET} ${SPARKLINE_15M:-}\n"
+      printf "${ACE_PRIMARY_DIM}├─ 60m:${RESET} ${SPARKLINE_1H:-}\n"
+      printf "${ACE_PRIMARY_DIM}├── 1d:${RESET} ${SPARKLINE_1D:-}\n"
+      printf "${ACE_PRIMARY_DIM}└── 1w:${RESET} ${SPARKLINE_1W:-}\n"
+      ;;
+  esac
+}
+
+# ─── TERMINAL WIDTH & MODE ──────────────────────────────────────────────────
+
+detect_terminal_width() {
+  local width=""
+
+  # Tier 1: Kitty IPC
+  if [ -n "${KITTY_WINDOW_ID:-}" ] && command -v kitten >/dev/null 2>&1; then
+    width=$(kitten @ ls 2>/dev/null | jq -r --argjson wid "$KITTY_WINDOW_ID" \
+      '.[].tabs[].windows[] | select(.id == $wid) | .columns' 2>/dev/null)
+  fi
+
+  # Tier 2: stty
+  if [ -z "$width" ] || [ "$width" = "0" ] || [ "$width" = "null" ]; then
+    width=$(stty size </dev/tty 2>/dev/null | awk '{print $2}')
+  fi
+
+  # Tier 3: tput
+  if [ -z "$width" ] || [ "$width" = "0" ]; then
+    width=$(tput cols 2>/dev/null)
+  fi
+
+  # Tier 4: fallback
+  if [ -z "$width" ] || [ "$width" = "0" ]; then
+    width=${COLUMNS:-80}
+  fi
+
+  echo "$width"
+}
+
+# ─── MAIN EXECUTION ─────────────────────────────────────────────────────────
+
+if [ "${_SOURCE_ONLY:-}" != "true" ]; then
+  # ─── PARSE INPUT ───────────────────────────────────────────────────────────
+
+  input=$(cat)
+
+  eval "$(echo "$input" | jq -r '
+    "session_id=" + (.session_id // "" | @sh) + "\n" +
+    "current_dir=" + (.workspace.current_dir // .cwd // "." | @sh) + "\n" +
+    "cc_model=" + (.model.display_name // "unknown" | @sh) + "\n" +
+    "cc_version=" + (.version // "" | @sh) + "\n" +
+    "cc_context_pct=" + (.context_window.used_percentage // 0 | tostring) + "\n" +
+    "cc_context_size=" + (.context_window.context_window_size // 200000 | tostring) + "\n" +
+    "cc_cost=" + (.cost.total_cost_usd // 0 | tostring) + "\n" +
+    "cc_duration_ms=" + (.cost.total_duration_ms // 0 | tostring) + "\n" +
+    "cc_lines_added=" + (.cost.total_lines_added // 0 | tostring) + "\n" +
+    "cc_lines_removed=" + (.cost.total_lines_removed // 0 | tostring)
+  ' 2>/dev/null)" || true
+
+  session_id="${session_id:-}"
+  current_dir="${current_dir:-.}"
+  dir_name=$(basename "$current_dir" 2>/dev/null || echo ".")
+
+  # If no session_id, minimal output
+  if [ -z "$session_id" ]; then
+    printf "${DIM}ACE: awaiting session${RESET}\n"
+    exit 0
+  fi
+
+  # ─── TERMINAL WIDTH & MODE ────────────────────────────────────────────────
+
+  term_width=$(detect_terminal_width)
+
+  if [ "$term_width" -lt 40 ]; then
+    MODE="nano"
+  elif [ "$term_width" -lt 60 ]; then
+    MODE="micro"
+  elif [ "$term_width" -lt 100 ]; then
+    MODE="mini"
+  else
+    MODE="normal"
+  fi
+
+  # Resolve ACE_RELEVANCE relative to project root
+  if [[ "$ACE_RELEVANCE" != /* ]]; then
+    ACE_RELEVANCE="${current_dir}/${ACE_RELEVANCE}"
+  fi
+
+  if [ ! -f "$ACE_RELEVANCE" ]; then
+    printf "${DIM}ACE: no data${RESET}\n"
+    exit 0
+  fi
+
+  # ─── GATHER DATA ───────────────────────────────────────────────────────────
+
+  aggregate_session "$session_id" "$ACE_RELEVANCE"
+  fetch_playbook_data
+  compute_qpt
+  compute_terrain
+
+  # Normalize all display metrics to percentage format for visual consistency
+  SESSION_CONFIDENCE_PCT=$(jq -n "${SESSION_CONFIDENCE:-0} * 100 | round")
+  if [ "${SESSION_LEARN_TOTAL:-0}" -gt 0 ]; then
+    SESSION_LEARN_PCT=$(jq -n "(${SESSION_LEARN_SENT} / ${SESSION_LEARN_TOTAL} * 100) | round")
+  else
+    SESSION_LEARN_PCT=0
+  fi
+  if [ "${SESSION_INJ_TOTAL:-0}" -gt 0 ]; then
+    SESSION_INJ_PCT=$(jq -n "(${SESSION_INJ_USED} / ${SESSION_INJ_TOTAL} * 100) | round")
+  else
+    SESSION_INJ_PCT=0
+  fi
+
+  # ─── BUILD SPARKLINES (mini & normal only) ────────────────────────────────
+
+  SPARKLINE_15M=""
+  SPARKLINE_1H=""
+  SPARKLINE_1D=""
+  SPARKLINE_1W=""
+  SPARK_COUNT_15M=0
+  SPARK_COUNT_1H=0
+  SPARK_COUNT_1D=0
+  SPARK_COUNT_1W=0
+
+  if [ "$MODE" = "normal" ] || [ "$MODE" = "mini" ]; then
+    buckets_15m=$(bucket_events "$ACE_RELEVANCE" 15 60)
+    buckets_1h=$(bucket_events "$ACE_RELEVANCE" 12 300)
+    buckets_1d=$(bucket_events "$ACE_RELEVANCE" 24 3600)
+    buckets_1w=$(bucket_events "$ACE_RELEVANCE" 7 86400)
+
+    SPARKLINE_15M=$(render_sparkline "$buckets_15m")
+    SPARKLINE_1H=$(render_sparkline "$buckets_1h")
+    SPARKLINE_1D=$(render_sparkline "$buckets_1d")
+    SPARKLINE_1W=$(render_sparkline "$buckets_1w")
+
+    # Count total events per window
+    SPARK_COUNT_15M=$(echo "$buckets_15m" | tr ' ' '\n' | awk '{s+=$1} END{print s+0}')
+    SPARK_COUNT_1H=$(echo "$buckets_1h" | tr ' ' '\n' | awk '{s+=$1} END{print s+0}')
+    SPARK_COUNT_1D=$(echo "$buckets_1d" | tr ' ' '\n' | awk '{s+=$1} END{print s+0}')
+    SPARK_COUNT_1W=$(echo "$buckets_1w" | tr ' ' '\n' | awk '{s+=$1} END{print s+0}')
+  fi
+
+  # ─── RENDER ──────────────────────────────────────────────────────────────
+
+  render_output
+fi

--- a/plugins/ace/scripts/ace-statusline.sh
+++ b/plugins/ace/scripts/ace-statusline.sh
@@ -28,7 +28,9 @@ fi
 # ─── CONFIGURATION ───────────────────────────────────────────────────────────
 
 ACE_RELEVANCE=".claude/data/logs/ace-relevance.jsonl"
-ACE_CACHE="/tmp/ace-statusline-cache${ACE_PROJECT_ID:+-$ACE_PROJECT_ID}.json"
+# Sanitize project ID for use in file path (strip chars unsafe in filenames)
+_safe_project_id="${ACE_PROJECT_ID//[^a-zA-Z0-9_-]/}"
+ACE_CACHE="/tmp/ace-statusline-cache${_safe_project_id:+-$_safe_project_id}.json"
 ACE_CACHE_TTL=60
 
 # ─── COLOR PALETTE (ACE brand: #2CF1BE primary, #212126 dark) ────────────────
@@ -143,6 +145,8 @@ aggregate_session() {
     return 0
   fi
 
+  # Security: jq @sh encoding sanitizes all field values before eval.
+  # The relevance file is written exclusively by ACE hooks in the project directory.
   eval "$(jq -rs --arg sid "$sid" '
     [ .[] | select(.session_id == $sid) ] as $events |
     if ($events | length) == 0 then
@@ -199,6 +203,106 @@ aggregate_session() {
 
 # ─── PLAYBOOK DATA (ACE-CLI CACHE) ─────────────────────────────────────────
 
+_parse_playbook_cache() {
+  local cache_file="$1"
+  local total
+  total=$(jq -r '.playbook.total_patterns // 0' "$cache_file" 2>/dev/null)
+  PLAYBOOK_PATTERNS="${total:-0}"
+
+  local helpful
+  helpful=$(jq -r '.playbook.helpful_total // 0' "$cache_file" 2>/dev/null)
+  helpful=${helpful%%.*}  # truncate float to integer for bash arithmetic
+  local harmful
+  harmful=$(jq -r '.playbook.harmful_total // 0' "$cache_file" 2>/dev/null)
+  harmful=${harmful%%.*}  # truncate float to integer for bash arithmetic
+  local denom=$((helpful + harmful))
+  if [ "$denom" -gt 0 ]; then
+    PLAYBOOK_HEALTHY_PCT=$((helpful * 100 / denom))
+  else
+    PLAYBOOK_HEALTHY_PCT=0
+  fi
+
+  local dom_count
+  dom_count=$(jq -r '.playbook.by_domain | length // 0' "$cache_file" 2>/dev/null)
+  PLAYBOOK_DOMAINS="${dom_count:-0}"
+
+  local top
+  top=$(jq -r '.top_domains // ""' "$cache_file" 2>/dev/null)
+  PLAYBOOK_TOP_DOMAINS="${top:-}"
+
+  local oname
+  oname=$(jq -r '.ace_org_name // ""' "$cache_file" 2>/dev/null)
+  ACE_ORG_NAME="${oname:-}"
+  local pname
+  pname=$(jq -r '.ace_project_name // ""' "$cache_file" 2>/dev/null)
+  ACE_PROJECT_NAME="${pname:-}"
+
+  # Usage / consumption limits
+  local pat_used pat_limit traces_used traces_limit api_used api_limit
+  pat_used=$(jq -r '.subscription.usage.patterns.used // 0' "$cache_file" 2>/dev/null)
+  pat_limit=$(jq -r '.subscription.usage.patterns.limit // 0' "$cache_file" 2>/dev/null)
+  traces_used=$(jq -r '.subscription.usage.traces_today.used // 0' "$cache_file" 2>/dev/null)
+  traces_limit=$(jq -r '.subscription.usage.traces_today.limit // 0' "$cache_file" 2>/dev/null)
+  api_used=$(jq -r '.subscription.usage.api_calls.used // 0' "$cache_file" 2>/dev/null)
+  api_limit=$(jq -r '.subscription.usage.api_calls.limit // 0' "$cache_file" 2>/dev/null)
+  USAGE_PATTERNS_USED="${pat_used:-0}"
+  USAGE_PATTERNS_LIMIT="${pat_limit:-0}"
+  USAGE_TRACES_USED="${traces_used:-0}"
+  USAGE_TRACES_LIMIT="${traces_limit:-0}"
+  USAGE_API_USED="${api_used:-0}"
+  USAGE_API_LIMIT="${api_limit:-0}"
+  if [ "${USAGE_PATTERNS_LIMIT:-0}" -gt 0 ] 2>/dev/null; then
+    USAGE_PATTERNS_PCT=$((USAGE_PATTERNS_USED * 100 / USAGE_PATTERNS_LIMIT))
+  else
+    USAGE_PATTERNS_PCT=0
+  fi
+}
+
+_bg_refresh_cache() {
+  local cache_file="$1"
+  (
+    local status_json
+    status_json=$(ace-cli status --json 2>/dev/null) || return
+    local domains_json
+    domains_json=$(ace-cli domains --json 2>/dev/null) || return
+
+    local top5
+    top5=$(echo "$domains_json" | jq -r '[.domains[:5][].name] | join(",")' 2>/dev/null)
+
+    # Resolve org name from whoami
+    local org_name=""
+    local whoami_json
+    if whoami_json=$(ace-cli whoami --json 2>/dev/null); then
+      local cur_org
+      cur_org=$(echo "$whoami_json" | jq -r '.current_org_id // ""' 2>/dev/null)
+      if [ -n "$cur_org" ]; then
+        org_name=$(echo "$whoami_json" | jq -r --arg oid "$cur_org" \
+          '.user.organizations[] | select(.org_id == $oid) | .name // ""' 2>/dev/null)
+      fi
+    fi
+
+    # Resolve project name from projects list
+    local proj_name=""
+    local proj_id="${ACE_PROJECT_ID:-}"
+    if [ -n "$proj_id" ]; then
+      local projects_json
+      if projects_json=$(ace-cli projects --json 2>/dev/null); then
+        proj_name=$(echo "$projects_json" | jq -r --arg pid "$proj_id" \
+          '.projects[] | select(.project_id == $pid) | .project_name // ""' 2>/dev/null)
+      fi
+    fi
+
+    echo "$status_json" | jq \
+      --arg td "$top5" \
+      --arg on "$org_name" \
+      --arg pn "$proj_name" \
+      '. + {top_domains: $td, ace_org_name: $on, ace_project_name: $pn}' \
+      >"${cache_file}.tmp" 2>/dev/null &&
+      mv "${cache_file}.tmp" "$cache_file"
+  ) &
+  disown
+}
+
 # fetch_playbook_data()
 # Reads ace-cli data from cache, refreshes in background when stale.
 # Sets: PLAYBOOK_PATTERNS, PLAYBOOK_HEALTHY_PCT, PLAYBOOK_DOMAINS, PLAYBOOK_TOP_DOMAINS,
@@ -221,106 +325,6 @@ fetch_playbook_data() {
 
   local now
   now=$(date +%s)
-
-  _parse_playbook_cache() {
-    local cache_file="$1"
-    local total
-    total=$(jq -r '.playbook.total_patterns // 0' "$cache_file" 2>/dev/null)
-    PLAYBOOK_PATTERNS="${total:-0}"
-
-    local helpful
-    helpful=$(jq -r '.playbook.helpful_total // 0' "$cache_file" 2>/dev/null)
-    helpful=${helpful%%.*}  # truncate float to integer for bash arithmetic
-    local harmful
-    harmful=$(jq -r '.playbook.harmful_total // 0' "$cache_file" 2>/dev/null)
-    harmful=${harmful%%.*}  # truncate float to integer for bash arithmetic
-    local denom=$((helpful + harmful))
-    if [ "$denom" -gt 0 ]; then
-      PLAYBOOK_HEALTHY_PCT=$((helpful * 100 / denom))
-    else
-      PLAYBOOK_HEALTHY_PCT=0
-    fi
-
-    local dom_count
-    dom_count=$(jq -r '.playbook.by_domain | length // 0' "$cache_file" 2>/dev/null)
-    PLAYBOOK_DOMAINS="${dom_count:-0}"
-
-    local top
-    top=$(jq -r '.top_domains // ""' "$cache_file" 2>/dev/null)
-    PLAYBOOK_TOP_DOMAINS="${top:-}"
-
-    local oname
-    oname=$(jq -r '.ace_org_name // ""' "$cache_file" 2>/dev/null)
-    ACE_ORG_NAME="${oname:-}"
-    local pname
-    pname=$(jq -r '.ace_project_name // ""' "$cache_file" 2>/dev/null)
-    ACE_PROJECT_NAME="${pname:-}"
-
-    # Usage / consumption limits
-    local pat_used pat_limit traces_used traces_limit api_used api_limit
-    pat_used=$(jq -r '.subscription.usage.patterns.used // 0' "$cache_file" 2>/dev/null)
-    pat_limit=$(jq -r '.subscription.usage.patterns.limit // 0' "$cache_file" 2>/dev/null)
-    traces_used=$(jq -r '.subscription.usage.traces_today.used // 0' "$cache_file" 2>/dev/null)
-    traces_limit=$(jq -r '.subscription.usage.traces_today.limit // 0' "$cache_file" 2>/dev/null)
-    api_used=$(jq -r '.subscription.usage.api_calls.used // 0' "$cache_file" 2>/dev/null)
-    api_limit=$(jq -r '.subscription.usage.api_calls.limit // 0' "$cache_file" 2>/dev/null)
-    USAGE_PATTERNS_USED="${pat_used:-0}"
-    USAGE_PATTERNS_LIMIT="${pat_limit:-0}"
-    USAGE_TRACES_USED="${traces_used:-0}"
-    USAGE_TRACES_LIMIT="${traces_limit:-0}"
-    USAGE_API_USED="${api_used:-0}"
-    USAGE_API_LIMIT="${api_limit:-0}"
-    if [ "${USAGE_PATTERNS_LIMIT:-0}" -gt 0 ] 2>/dev/null; then
-      USAGE_PATTERNS_PCT=$((USAGE_PATTERNS_USED * 100 / USAGE_PATTERNS_LIMIT))
-    else
-      USAGE_PATTERNS_PCT=0
-    fi
-  }
-
-  _bg_refresh_cache() {
-    local cache_file="$1"
-    (
-      local status_json
-      status_json=$(ace-cli status --json 2>/dev/null) || return
-      local domains_json
-      domains_json=$(ace-cli domains --json 2>/dev/null) || return
-
-      local top5
-      top5=$(echo "$domains_json" | jq -r '[.domains[:5][].name] | join(",")' 2>/dev/null)
-
-      # Resolve org name from whoami
-      local org_name=""
-      local whoami_json
-      if whoami_json=$(ace-cli whoami --json 2>/dev/null); then
-        local cur_org
-        cur_org=$(echo "$whoami_json" | jq -r '.current_org_id // ""' 2>/dev/null)
-        if [ -n "$cur_org" ]; then
-          org_name=$(echo "$whoami_json" | jq -r --arg oid "$cur_org" \
-            '.user.organizations[] | select(.org_id == $oid) | .name // ""' 2>/dev/null)
-        fi
-      fi
-
-      # Resolve project name from projects list
-      local proj_name=""
-      local proj_id="${ACE_PROJECT_ID:-}"
-      if [ -n "$proj_id" ]; then
-        local projects_json
-        if projects_json=$(ace-cli projects --json 2>/dev/null); then
-          proj_name=$(echo "$projects_json" | jq -r --arg pid "$proj_id" \
-            '.projects[] | select(.project_id == $pid) | .project_name // ""' 2>/dev/null)
-        fi
-      fi
-
-      echo "$status_json" | jq \
-        --arg td "$top5" \
-        --arg on "$org_name" \
-        --arg pn "$proj_name" \
-        '. + {top_domains: $td, ace_org_name: $on, ace_project_name: $pn}' \
-        >"${cache_file}.tmp" 2>/dev/null &&
-        mv "${cache_file}.tmp" "$cache_file"
-    ) &
-    disown
-  }
 
   if [ -f "$ACE_CACHE" ]; then
     local mtime
@@ -347,12 +351,13 @@ compute_qpt() {
     learn_rate=$(jq -n "${SESSION_LEARN_SENT} / ${SESSION_LEARN_TOTAL}")
   fi
 
-  ACE_QPT=$(jq -n "
-    (${SESSION_FOCUS_PCT:-0} / 100 * 0.35 +
-     ${SESSION_CONFIDENCE:-0} * 0.30 +
-     $learn_rate * 0.20 +
-     ${SESSION_SUCCESS_RATE:-0} / 100 * 0.15) * 100 | round
-  ")
+  ACE_QPT=$(jq -n \
+    --argjson focus    "${SESSION_FOCUS_PCT:-0}" \
+    --argjson conf     "${SESSION_CONFIDENCE:-0}" \
+    --argjson learn    "$learn_rate" \
+    --argjson success  "${SESSION_SUCCESS_RATE:-0}" \
+    '($focus / 100 * 0.35 + $conf * 0.30 + $learn * 0.20 + $success / 100 * 0.15) * 100 | round'
+  )
   ACE_QPT="${ACE_QPT:-0}"
 }
 
@@ -407,7 +412,7 @@ render_sparkline() {
   fi
 
   # PAI-style: block height encodes value level, color encodes quality band
-  # 10 levels mapped to 5 block heights with distinct colors
+  # value scaled to ceiling [1,10] then mapped to 5 display tiers
   # High activity = tall green, low activity = short red
   local out=""
   for val in "${buckets[@]}"; do
@@ -457,7 +462,7 @@ bucket_events() {
   local input_file="$relevance_file"
   local tmp_file=""
   if [ "$max_lines" -gt 0 ]; then
-    tmp_file="/tmp/ace-bucket-$$"
+    tmp_file=$(mktemp /tmp/ace-bucket-XXXXXX)
     tail -n "$max_lines" "$relevance_file" >"$tmp_file" 2>/dev/null
     input_file="$tmp_file"
   fi
@@ -467,7 +472,7 @@ bucket_events() {
     --argjson bsec "$bucket_seconds" \
     --argjson nbuckets "$num_buckets" '
     [.[] | select(type == "object" and has("timestamp")) | .timestamp |
-      (sub("[.+Z].*$"; "") + "Z" | fromdateiso8601) as $ts |
+      (sub("(\\.[0-9]+)?([Z+].*)?$"; "") + "Z" | fromdateiso8601) as $ts |
       select($ts >= $start) |
       (($ts - $start) / $bsec | floor)
     ] as $indices |
@@ -599,6 +604,7 @@ if [ "${_SOURCE_ONLY:-}" != "true" ]; then
 
   input=$(cat)
 
+  # Security: input comes from Claude Code (trusted). jq @sh encoding applied before eval.
   eval "$(echo "$input" | jq -r '
     "session_id=" + (.session_id // "" | @sh) + "\n" +
     "current_dir=" + (.workspace.current_dir // .cwd // "." | @sh)

--- a/plugins/ace/scripts/ace-statusline.sh
+++ b/plugins/ace/scripts/ace-statusline.sh
@@ -487,124 +487,9 @@ bucket_events() {
   fi
 }
 
-# ─── CC (CLAUDE CODE) STATUS LINE ──────────────────────────────────────────
-
-# Colors for CC section
-CC_PRIMARY='\033[38;2;129;140;248m'     # Indigo
-CC_SECONDARY='\033[38;2;165;180;252m'   # Light indigo
-CC_BUCKET_EMPTY='\033[38;2;75;82;95m'
-
-get_cc_bucket_color() {
-  local pos=$1 max=$2
-  local pct=$((pos * 100 / max))
-  local r g b
-  if [ "$pct" -le 33 ]; then
-    r=$((74 + (250 - 74) * pct / 33))
-    g=$((222 + (204 - 222) * pct / 33))
-    b=$((128 + (21 - 128) * pct / 33))
-  elif [ "$pct" -le 66 ]; then
-    local t=$((pct - 33))
-    r=$((250 + (251 - 250) * t / 33))
-    g=$((204 + (146 - 204) * t / 33))
-    b=$((21 + (60 - 21) * t / 33))
-  else
-    local t=$((pct - 66))
-    r=$((251 + (239 - 251) * t / 34))
-    g=$((146 + (68 - 146) * t / 34))
-    b=$((60 + (68 - 60) * t / 34))
-  fi
-  printf '\033[38;2;%d;%d;%dm' "$r" "$g" "$b"
-}
-
-render_cc_context_bar() {
-  local width=$1 pct=$2
-  local output=""
-  [ "$pct" -gt 100 ] && pct=100
-  local filled=$((pct * width / 100))
-  [ "$filled" -lt 0 ] && filled=0
-  local i
-  for ((i = 1; i <= width; i++)); do
-    if [ "$i" -le "$filled" ]; then
-      local color
-      color=$(get_cc_bucket_color "$i" "$width")
-      output="${output}${color}⛁${RESET}"
-    else
-      output="${output}${CC_BUCKET_EMPTY}⛁${RESET}"
-    fi
-  done
-  echo -e "$output"
-}
-
-render_cc_status() {
-  local pct="${cc_context_pct:-0}"
-  pct="${pct%%.*}"
-  [ -z "$pct" ] && pct=0
-
-  # Context color
-  local pct_color
-  if [ "$pct" -ge 80 ]; then
-    pct_color='\033[38;2;251;113;133m'   # Rose
-  elif [ "$pct" -ge 60 ]; then
-    pct_color='\033[38;2;251;146;60m'    # Orange
-  elif [ "$pct" -ge 40 ]; then
-    pct_color='\033[38;2;251;191;36m'    # Yellow
-  else
-    pct_color="${GREEN}"                  # Green
-  fi
-
-  # Format duration
-  local dur_sec=$(( ${cc_duration_ms:-0} / 1000 ))
-  local time_display
-  if [ "$dur_sec" -ge 3600 ]; then
-    time_display="$((dur_sec / 3600))h$((dur_sec % 3600 / 60))m"
-  elif [ "$dur_sec" -ge 60 ]; then
-    time_display="$((dur_sec / 60))m$((dur_sec % 60))s"
-  else
-    time_display="${dur_sec}s"
-  fi
-
-  # Format cost
-  local cost_display
-  cost_display=$(printf '$%.2f' "${cc_cost:-0}")
-
-  case "$MODE" in
-    nano)
-      printf "${DIM}${cc_model:-?}${RESET} ${pct_color}${pct}%%${RESET} ${DIM}${cost_display}${RESET}\n"
-      ;;
-    micro)
-      printf "${CC_PRIMARY}◉${RESET} ${pct_color}${pct}%%${RESET}"
-      printf " ${DIM}${cc_model:-?}${RESET}"
-      printf " ${DIM}${cost_display}${RESET}"
-      printf " ${DIM}${time_display}${RESET}\n"
-      ;;
-    mini)
-      local bar
-      bar=$(render_cc_context_bar 20 "$pct")
-      printf "${CC_PRIMARY}◉${RESET} ${CC_SECONDARY}CTX:${RESET} ${bar} ${pct_color}${pct}%%${RESET}"
-      printf "  ${DIM}${cc_model:-?}${RESET}"
-      printf "  ${DIM}${cost_display}${RESET}"
-      printf "  ${DIM}${time_display}${RESET}\n"
-      ;;
-    normal)
-      local bar
-      bar=$(render_cc_context_bar 40 "$pct")
-      printf "${CC_PRIMARY}◉${RESET} ${CC_SECONDARY}CTX:${RESET} ${bar} ${pct_color}${pct}%%${RESET}\n"
-      printf "${CC_PRIMARY}▸${RESET} ${DIM}Model:${RESET} ${BOLD}${cc_model:-?}${RESET}"
-      printf "  ${DIM}Cost:${RESET} ${cost_display}"
-      printf "  ${DIM}Time:${RESET} ${time_display}"
-      printf "  ${DIM}CC-Lines:${RESET} +${cc_lines_added:-0}/-${cc_lines_removed:-0}"
-      [ -n "${cc_version}" ] && printf "  ${DIM}CC:${RESET} ${cc_version}"
-      printf "\n"
-      ;;
-  esac
-}
-
 # ─── RENDER OUTPUT ──────────────────────────────────────────────────────────
 
 render_output() {
-  # ── CC status first ──
-  render_cc_status
-
   local sc
   sc=$(qpt_color "${ACE_QPT:-0}")
 
@@ -716,15 +601,7 @@ if [ "${_SOURCE_ONLY:-}" != "true" ]; then
 
   eval "$(echo "$input" | jq -r '
     "session_id=" + (.session_id // "" | @sh) + "\n" +
-    "current_dir=" + (.workspace.current_dir // .cwd // "." | @sh) + "\n" +
-    "cc_model=" + (.model.display_name // "unknown" | @sh) + "\n" +
-    "cc_version=" + (.version // "" | @sh) + "\n" +
-    "cc_context_pct=" + (.context_window.used_percentage // 0 | tostring) + "\n" +
-    "cc_context_size=" + (.context_window.context_window_size // 200000 | tostring) + "\n" +
-    "cc_cost=" + (.cost.total_cost_usd // 0 | tostring) + "\n" +
-    "cc_duration_ms=" + (.cost.total_duration_ms // 0 | tostring) + "\n" +
-    "cc_lines_added=" + (.cost.total_lines_added // 0 | tostring) + "\n" +
-    "cc_lines_removed=" + (.cost.total_lines_removed // 0 | tostring)
+    "current_dir=" + (.workspace.current_dir // .cwd // "." | @sh)
   ' 2>/dev/null)" || true
 
   session_id="${session_id:-}"


### PR DESCRIPTION
## Summary

Integrates the production-quality ACE statusline script into the marketplace as an official plugin component, with a setup slash command and full documentation. All changes are additive — zero existing plugin files modified except the guides README index.

**Impact**: 5 files, ~1592 net insertions · **Risk**: 🟢 Low · **Review time**: ~20 min

---

## What Changed

### 🔧 Script
- **`plugins/ace/scripts/ace-statusline.sh`** (693 lines, new) — Reads session metrics from `ace-relevance.jsonl` (<10ms, no cache) and playbook health from `ace-cli status` (60s background `/tmp/` cache). Responsive across 4 terminal widths. ACE metrics only — CC section omitted as redundant.

### ⚙️ Command
- **`plugins/ace/commands/ace-statusline-setup.md`** (218 lines, new) — `/ace-statusline-setup` slash command. Two rounds of prompt engineering review applied. Key behaviours:
  - `jq` prerequisite gate with platform-specific install instructions
  - 3-tier path resolution: `CLAUDE_PLUGIN_ROOT` → XDG config → macOS `Application Support`
  - Marketplace directory discovery hint when all three fail
  - Mechanical `ALREADY_WIRED` / `NEEDS_WIRING` idempotency signal (no LLM reasoning required)
  - `printf`-based wrapper write with CRITICAL guard against placeholder leakage
  - `INVALID_JSON` branch discloses partial-state explicitly
  - Atomic `jq` rewrite with `MERGE_FAILED` guard + temp file cleanup
  - Per-step `Tell the user:` narration; explicit stop signal after Step 5

### 📝 Docs
- **`plugins/ace/docs/guides/STATUSLINE.md`** (363 lines, new) — Component reference. Every ACE metric with formula, range, and "when to act" interpretation. Formulas verified against the script. At-a-glance table, ASCII data flow diagram, "what disappears" responsive mode table.
- **`plugins/ace/docs/guides/STATUSLINE-TUTORIAL.md`** (307 lines, new) — Getting started guide. Problem-first opening, full dashboard rendered before breakdown, first-run mechanics section, troubleshooting with Symptom → Mental model → Fix structure.
- **`plugins/ace/docs/guides/README.md`** — Index entries for the two new docs.

---

## QPT (Quality Per Task)

Replaces SCORE throughout. Formula:

```
QPT = (Focus/100 × 0.35) + (Confidence × 0.30) + (LearnRate × 0.20) + (SuccessRate/100 × 0.15)  × 100 | round
```

| Score | Color | Meaning |
|-------|-------|---------|
| ≥70 | 🟢 Green | High effectiveness |
| 40–69 | 🟡 Yellow | Moderate |
| <40 | 🔴 Red | Low — patterns may not be landing |

---

## Responsive Display Modes

| Mode | Width | Shows |
|------|-------|-------|
| nano | <40 | QPT |
| micro | 40–59 | QPT, Focus, Conf |
| mini | 60–99 | QPT, Focus, Conf, Inj, playbook health ratio |
| normal | ≥100 | Full dashboard: all metrics + PLAYBOOK + USAGE bar + LEARNING sparklines |

---

## Update Timing

Runs **after each assistant response**, debounced at 300ms.

- `ace-relevance.jsonl` → read fresh each invocation (<10ms, no cache)
- `ace-cli status` → 60s `/tmp/` cache, background refresh when stale
- No polling when idle — open feature request: [issue #5685](https://github.com/anthropics/claude-code/issues/5685)

---

## Security Notes

The script uses `eval` in two places, both protected:
- `aggregate_session`: `eval "$(jq -rs ... @sh ...)"` — ACE-controlled write path; `@sh` encoding applied
- Main block stdin parse: `eval "$(jq -r ... @sh ...)"` — input from Claude Code (trusted); `@sh` encoding applied

Both eval sites have explicit security comments in the code.

---

## Risk Assessment

| Factor | Level | Notes |
|--------|-------|-------|
| Scope | 🟢 Low | Additive only — zero existing plugin files modified |
| Bash safety | 🟢 Low | `bash -n` passes; variables quoted; no user input in exec |
| Setup idempotency | 🟢 Low | Mechanical grep signal; targeted `jq .statusLine.command =` write |
| Path safety | 🟢 Low | exec path double-quoted; `Application Support` spaces handled |
| JSON safety | 🟢 Low | Atomic tmp→rename; `INVALID_JSON` and `MERGE_FAILED` branches |
| Security | 🟢 Low | `eval` sites use `@sh` encoding + security comments; `ACE_PROJECT_ID` sanitized in cache path |
| Timestamps | 🟢 Low | Regex fixed to correctly handle offset-aware ISO 8601 (`+05:30`, `+00:00`) |

---

## Review Checklist

### Script (`ace-statusline.sh`)
- [ ] No residual `ACE_SCORE`, `compute_score`, `score_color`, or `SCORE:` references (all renamed to QPT)
- [ ] No residual CC section code (`render_cc_status`, `cc_model`, `cc_cost`, etc.)
- [ ] `bash -n` syntax check passes
- [ ] QPT formula weights sum to 1.0: 0.35 + 0.30 + 0.20 + 0.15 = 1.0 ✅
- [ ] `compute_qpt` uses `--argjson` (not shell variable interpolation into jq string)
- [ ] `_parse_playbook_cache` and `_bg_refresh_cache` defined at module scope (not nested)
- [ ] `ACE_PROJECT_ID` sanitized before use in cache path
- [ ] Timestamp regex: `sub("(\\.[0-9]+)?([Z+].*)?$"; "")` handles offset-aware timestamps
- [ ] Temp file in `bucket_events` uses `mktemp`

### Setup Command (`ace-statusline-setup.md`)
- [ ] Step 1: `jq` gate with `JQ_NOT_FOUND` sentinel
- [ ] Step 2: 3-tier resolution; `FOUND:` prefix extracted as `STATUSLINE_PATH`
- [ ] Step 3: `grep -qF` produces `ALREADY_WIRED` / `NEEDS_WIRING` mechanically
- [ ] Step 4.2: `printf`-based write with CRITICAL guard; exec path double-quoted
- [ ] Step 4.4: `NOT_PRESENT` / `VALID_JSON` (atomic tmp rename) / `INVALID_JSON` branches; `MERGE_FAILED` guard
- [ ] Step 5: verification block runs even on `ALREADY_WIRED` fast-path

### Docs
- [ ] No CC section references remaining in either doc
- [ ] QPT formula matches script (weights + normalization)
- [ ] Terrain thresholds: ≥70% familiar, 30–69% exploring, <30% blind spot
- [ ] STATUSLINE.md and tutorial agree on PLAYBOOK healthy ratio threshold (≥80%)
- [ ] STATUSLINE-TUTORIAL.md section 7: 300ms debounce + no-idle-polling + issue #5685

---

## Test Plan

```bash
# Syntax check
bash -n plugins/ace/scripts/ace-statusline.sh && echo "SYNTAX OK"

# Wire and verify
/ace-statusline-setup
# → .claude/statusline-command.sh created (executable), settings.local.json updated

# Restart Claude Code — statusline should appear (ACE metrics only)
# Run a task — QPT/Focus/Conf update after Stop hook fires
# Resize below 40/60/100 cols — verify mode switches
# Re-run /ace-statusline-setup — verify ALREADY_WIRED fast-path, no file changes
# Test with invalid settings.local.json — verify INVALID_JSON stop with clear message
```